### PR TITLE
feat(weld): implement network policy enforcement for HTTP requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4545,8 +4545,12 @@ name = "wassette"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "component2json",
  "futures",
+ "http",
+ "http-body-util",
+ "hyper",
  "oci-client",
  "oci-wasm",
  "policy-mcp",
@@ -4565,6 +4569,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "url",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-config",

--- a/crates/component2json/src/lib.rs
+++ b/crates/component2json/src/lib.rs
@@ -695,7 +695,7 @@ mod tests {
     #[test]
     fn test_vals_to_json_single() {
         let val = Val::Bool(true);
-        let json_val = vals_to_json(&[val.clone()]);
+        let json_val = vals_to_json(std::slice::from_ref(&val));
         assert_eq!(json_val, val_to_json(&val));
     }
 

--- a/crates/wassette/Cargo.toml
+++ b/crates/wassette/Cargo.toml
@@ -6,8 +6,12 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bytes = "1"
 component2json = { path = "../component2json" }
 futures = { workspace = true }
+http = "1.0"
+http-body-util = "0.1"
+hyper = { version = "1.0", features = ["client"] }
 oci-client = { workspace = true }
 oci-wasm = { workspace = true }
 policy-mcp = { workspace = true }
@@ -20,6 +24,7 @@ tokio = { workspace = true, features = ["full", "test-util"] }
 tokio-stream = { workspace = true, features = ["fs"] }
 tokio-util = { workspace = true, features = ["io"] }
 tracing = { workspace = true, features = ["attributes"] }
+url = "2.5"
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }

--- a/crates/wassette/src/http.rs
+++ b/crates/wassette/src/http.rs
@@ -1,0 +1,304 @@
+use std::collections::HashSet;
+
+use anyhow::Result;
+use tracing::{debug, warn};
+use url::Url;
+use wasmtime::component::Resource;
+use wasmtime_wasi::p2::{IoView, WasiView};
+use wasmtime_wasi_http::bindings::http::types;
+use wasmtime_wasi_http::types::{HostFutureIncomingResponse, OutgoingRequestConfig};
+use wasmtime_wasi_http::{HttpResult, WasiHttpView};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct AllowedHost {
+    scheme: Option<String>,
+    host: String,
+}
+
+impl AllowedHost {
+    fn from_str(host_str: &str) -> Result<Self> {
+        if let Ok(url) = Url::parse(host_str) {
+            Ok(AllowedHost {
+                scheme: Some(url.scheme().to_string()),
+                host: url.host_str().unwrap_or("").to_string(),
+            })
+        } else if let Ok(url) = Url::parse(&format!("http://{host_str}")) {
+            Ok(AllowedHost {
+                scheme: None,
+                host: url.host_str().unwrap_or("").to_string(),
+            })
+        } else {
+            Err(anyhow::anyhow!("Invalid host format: {}", host_str))
+        }
+    }
+
+    fn matches(&self, request_host: &str, request_scheme: Option<&str>) -> bool {
+        if self.host != request_host {
+            return false;
+        }
+
+        match (&self.scheme, request_scheme) {
+            (Some(allowed_scheme), Some(req_scheme)) => allowed_scheme == req_scheme,
+            _ => true,
+        }
+    }
+}
+
+/// WeldWasiState is a wrapper around a WASI state that enforces network policies by filtering outgoing HTTP requests
+/// based on a list of allowed hosts from the component's policy document.
+pub struct WeldWasiState<T> {
+    /// The underlying WASI state
+    pub inner: T,
+
+    /// Set of allowed hosts for network requests (extracted from policy document)
+    allowed_hosts: HashSet<AllowedHost>,
+}
+
+impl<T> WeldWasiState<T> {
+    /// Create a new WeldWasiState with the given allowed hosts
+    pub fn new(inner: T, allowed_hosts: HashSet<String>) -> Result<Self> {
+        let mut parsed_hosts = HashSet::new();
+
+        for host_str in allowed_hosts {
+            match AllowedHost::from_str(&host_str) {
+                Ok(parsed_host) => {
+                    parsed_hosts.insert(parsed_host);
+                }
+                Err(e) => {
+                    warn!("Failed to parse allowed host '{}': {}", host_str, e);
+                    return Err(e);
+                }
+            }
+        }
+
+        Ok(Self {
+            inner,
+            allowed_hosts: parsed_hosts,
+        })
+    }
+
+    /// Check if a host is allowed by the policy
+    fn is_host_allowed(&self, uri: &hyper::Uri) -> bool {
+        let request_host = if let Some(host) = uri.host() {
+            host.to_string()
+        } else {
+            return false;
+        };
+
+        let request_scheme = uri.scheme().map(|s| s.as_str());
+
+        let req = request_host.to_ascii_lowercase();
+        for allowed_host in &self.allowed_hosts {
+            if allowed_host.matches(&req, request_scheme) {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+impl<T: IoView> IoView for WeldWasiState<T> {
+    fn table(&mut self) -> &mut wasmtime_wasi::ResourceTable {
+        self.inner.table()
+    }
+}
+
+impl<T: WasiView> WasiView for WeldWasiState<T> {
+    fn ctx(&mut self) -> &mut wasmtime_wasi::p2::WasiCtx {
+        self.inner.ctx()
+    }
+}
+
+impl<T: WasiHttpView> WasiHttpView for WeldWasiState<T> {
+    fn ctx(&mut self) -> &mut wasmtime_wasi_http::WasiHttpCtx {
+        self.inner.ctx()
+    }
+
+    fn new_response_outparam(
+        &mut self,
+        result: tokio::sync::oneshot::Sender<
+            Result<hyper::Response<wasmtime_wasi_http::body::HyperOutgoingBody>, types::ErrorCode>,
+        >,
+    ) -> wasmtime::Result<Resource<wasmtime_wasi_http::types::HostResponseOutparam>> {
+        self.inner.new_response_outparam(result)
+    }
+
+    fn send_request(
+        &mut self,
+        request: hyper::Request<wasmtime_wasi_http::body::HyperOutgoingBody>,
+        config: OutgoingRequestConfig,
+    ) -> HttpResult<HostFutureIncomingResponse> {
+        let uri = request.uri();
+
+        if uri.host().is_none() {
+            warn!("HTTP request missing host, blocking request");
+            return Err(types::ErrorCode::HttpRequestUriInvalid.into());
+        }
+
+        if !self.is_host_allowed(uri) {
+            warn!(
+                uri = %uri,
+                allowed_hosts = ?self.allowed_hosts,
+                "HTTP request blocked by network policy"
+            );
+            return Err(types::ErrorCode::HttpRequestDenied.into());
+        }
+
+        debug!(uri = %uri, "HTTP request allowed by network policy");
+
+        self.inner.send_request(request, config)
+    }
+
+    fn is_forbidden_header(&mut self, name: &hyper::header::HeaderName) -> bool {
+        self.inner.is_forbidden_header(name)
+    }
+
+    fn outgoing_body_buffer_chunks(&mut self) -> usize {
+        self.inner.outgoing_body_buffer_chunks()
+    }
+
+    fn outgoing_body_chunk_size(&mut self) -> usize {
+        self.inner.outgoing_body_chunk_size()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    fn create_mock_wasi_state() -> MockWasiState {
+        MockWasiState
+    }
+
+    struct MockWasiState;
+
+    impl IoView for MockWasiState {
+        fn table(&mut self) -> &mut wasmtime_wasi::ResourceTable {
+            unimplemented!("Mock for testing")
+        }
+    }
+
+    impl WasiHttpView for MockWasiState {
+        fn ctx(&mut self) -> &mut wasmtime_wasi_http::WasiHttpCtx {
+            unimplemented!("Mock for testing")
+        }
+
+        fn new_response_outparam(
+            &mut self,
+            _result: tokio::sync::oneshot::Sender<
+                Result<
+                    hyper::Response<wasmtime_wasi_http::body::HyperOutgoingBody>,
+                    types::ErrorCode,
+                >,
+            >,
+        ) -> wasmtime::Result<Resource<wasmtime_wasi_http::types::HostResponseOutparam>> {
+            unimplemented!("Mock for testing")
+        }
+
+        fn send_request(
+            &mut self,
+            _request: hyper::Request<wasmtime_wasi_http::body::HyperOutgoingBody>,
+            _config: OutgoingRequestConfig,
+        ) -> HttpResult<HostFutureIncomingResponse> {
+            unimplemented!("Mock for testing")
+        }
+    }
+
+    #[test]
+    fn test_host_allowed_exact_match() {
+        let mut allowed_hosts = HashSet::new();
+        allowed_hosts.insert("api.example.com".to_string());
+
+        let state = WeldWasiState::new(create_mock_wasi_state(), allowed_hosts).unwrap();
+
+        let uri1: hyper::Uri = "http://api.example.com".parse().unwrap();
+        let uri2: hyper::Uri = "http://other.example.com".parse().unwrap();
+        let uri3: hyper::Uri = "http://malicious.com".parse().unwrap();
+
+        assert!(state.is_host_allowed(&uri1));
+        assert!(!state.is_host_allowed(&uri2));
+        assert!(!state.is_host_allowed(&uri3));
+    }
+
+    #[test]
+    fn test_host_allowed_with_protocol() {
+        let mut allowed_hosts = HashSet::new();
+        allowed_hosts.insert("https://api.example.com".to_string());
+
+        let state = WeldWasiState::new(create_mock_wasi_state(), allowed_hosts).unwrap();
+
+        let uri1: hyper::Uri = "http://api.example.com".parse().unwrap();
+        let uri2: hyper::Uri = "https://api.example.com".parse().unwrap();
+        let uri3: hyper::Uri = "http://api.example.com".parse().unwrap();
+
+        assert!(!state.is_host_allowed(&uri1));
+        assert!(state.is_host_allowed(&uri2));
+        assert!(!state.is_host_allowed(&uri3));
+    }
+
+    #[test]
+    fn test_host_allowed_with_port() {
+        let mut allowed_hosts = HashSet::new();
+        allowed_hosts.insert("api.example.com".to_string());
+
+        let state = WeldWasiState::new(create_mock_wasi_state(), allowed_hosts).unwrap();
+
+        let uri1: hyper::Uri = "http://api.example.com:8080".parse().unwrap();
+        let uri2: hyper::Uri = "http://api.example.com:443".parse().unwrap();
+
+        assert!(state.is_host_allowed(&uri1));
+        assert!(state.is_host_allowed(&uri2));
+    }
+
+    #[test]
+    fn test_scheme_specific_matching() {
+        let mut allowed_hosts = HashSet::new();
+        allowed_hosts.insert("https://secure.api.com".to_string());
+        allowed_hosts.insert("api.example.com".to_string()); // scheme-agnostic
+
+        let state = WeldWasiState::new(create_mock_wasi_state(), allowed_hosts).unwrap();
+
+        // Scheme-specific host should only match HTTPS
+        let https_secure: hyper::Uri = "https://secure.api.com".parse().unwrap();
+        let http_secure: hyper::Uri = "http://secure.api.com".parse().unwrap();
+
+        assert!(state.is_host_allowed(&https_secure));
+        assert!(!state.is_host_allowed(&http_secure));
+
+        // Scheme-agnostic host should match both
+        let https_example: hyper::Uri = "https://api.example.com".parse().unwrap();
+        let http_example: hyper::Uri = "http://api.example.com".parse().unwrap();
+
+        assert!(state.is_host_allowed(&https_example));
+        assert!(state.is_host_allowed(&http_example));
+    }
+
+    #[test]
+    fn test_new_with_invalid_host() {
+        let mut allowed_hosts = HashSet::new();
+        allowed_hosts.insert("http://".to_string());
+        allowed_hosts.insert("".to_string());
+
+        match WeldWasiState::new(create_mock_wasi_state(), allowed_hosts) {
+            Ok(_) => panic!("Expected error, got Ok"),
+            Err(e) => assert!(e.to_string().contains("Invalid host format")),
+        }
+    }
+
+    #[test]
+    fn test_host_matching_is_case_insensitive() {
+        let mut allowed_hosts = HashSet::new();
+        allowed_hosts.insert("api.example.com".to_string());
+
+        let state = WeldWasiState::new(create_mock_wasi_state(), allowed_hosts).unwrap();
+
+        let uri1: hyper::Uri = "http://api.example.com".parse().unwrap();
+        let uri2: hyper::Uri = "http://API.EXAMPLE.COM".parse().unwrap();
+
+        assert!(state.is_host_allowed(&uri1));
+        assert!(state.is_host_allowed(&uri2));
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,61 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+#[allow(dead_code)]
+pub async fn build_fetch_component() -> Result<PathBuf> {
+    let top_level =
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").context("CARGO_MANIFEST_DIR not set")?);
+
+    let component_path =
+        top_level.join("examples/fetch-rs/target/wasm32-wasip2/release/fetch_rs.wasm");
+
+    let status = tokio::process::Command::new("cargo")
+        .current_dir(top_level.join("examples/fetch-rs"))
+        .args(["build", "--release", "--target", "wasm32-wasip2"])
+        .status()
+        .await
+        .context("Failed to execute cargo component build")?;
+
+    if !status.success() {
+        anyhow::bail!("Failed to compile fetch-rs component");
+    }
+
+    if !component_path.exists() {
+        anyhow::bail!(
+            "Component file not found after build: {}",
+            component_path.display()
+        );
+    }
+
+    Ok(component_path)
+}
+
+#[allow(dead_code)]
+pub async fn build_filesystem_component() -> Result<PathBuf> {
+    let top_level =
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").context("CARGO_MANIFEST_DIR not set")?);
+
+    let component_path =
+        top_level.join("examples/filesystem-rs/target/wasm32-wasip2/release/filesystem.wasm");
+
+    let status = tokio::process::Command::new("cargo")
+        .current_dir(top_level.join("examples/filesystem-rs"))
+        .args(["build", "--release", "--target", "wasm32-wasip2"])
+        .status()
+        .await
+        .context("Failed to execute cargo component build")?;
+
+    if !status.success() {
+        anyhow::bail!("Failed to compile filesystem component");
+    }
+
+    if !component_path.exists() {
+        anyhow::bail!(
+            "Component file not found after build: {}",
+            component_path.display()
+        );
+    }
+
+    Ok(component_path)
+}

--- a/tests/fetch_integration_test.rs
+++ b/tests/fetch_integration_test.rs
@@ -1,0 +1,222 @@
+use anyhow::{Context, Result};
+use tempfile::TempDir;
+use wassette::LifecycleManager;
+
+mod common;
+use common::build_fetch_component;
+
+async fn setup_lifecycle_manager() -> Result<(LifecycleManager, TempDir)> {
+    let tempdir = tempfile::tempdir().context("Failed to create temporary directory")?;
+    let manager = LifecycleManager::new(&tempdir).await?;
+    Ok((manager, tempdir))
+}
+
+#[tokio::test]
+async fn test_fetch_with_network_policy_enforcement() -> Result<()> {
+    let (manager, _tempdir) = setup_lifecycle_manager().await?;
+    let component_path = build_fetch_component().await?;
+
+    let (component_id, _) = manager
+        .load_component(&format!("file://{}", component_path.to_str().unwrap()))
+        .await?;
+
+    let target_url = "https://example.com/";
+
+    println!("Attempting to fetch {target_url} without network permissions...");
+
+    let result = manager
+        .execute_component_call(
+            &component_id,
+            "fetch",
+            &serde_json::json!({"url": target_url}).to_string(),
+        )
+        .await;
+
+    match result {
+        Ok(response) => {
+            println!("Component response: {response}");
+
+            // Check if the response contains an error indicating the request was blocked
+            if response.contains("HttpRequestDenied") {
+                println!("✅ Network request properly blocked by policy!");
+            } else {
+                panic!(
+                    "Expected network request to be blocked, but got successful response: {response}"
+                );
+            }
+        }
+        Err(e) => {
+            panic!("Expected network request to be blocked, but got successful response: {e}");
+        }
+    }
+
+    // Then grant network permission for example.com
+
+    let grant_result = manager
+        .grant_permission(
+            &component_id,
+            "network",
+            &serde_json::json!({"host": "example.com"}),
+        )
+        .await;
+
+    assert!(grant_result.is_ok(), "Failed to grant network permission");
+
+    // Then try to fetch with network permissions - should succeed
+    println!("Attempting to fetch {target_url} with network permissions...");
+
+    let result = manager
+        .execute_component_call(
+            &component_id,
+            "fetch",
+            &serde_json::json!({"url": target_url}).to_string(),
+        )
+        .await;
+
+    match result {
+        Ok(response) => {
+            println!("Fetch response after granting permission: {response}");
+
+            if response.contains("HttpRequestDenied") {
+                panic!("Network request still being blocked after granting permission: {response}");
+            } else {
+                assert!(
+                    response.contains("Example Domain") || response.contains("example"),
+                    "Expected response to contain example.com content, got: {response}"
+                );
+                println!("✅ Network request succeeded after granting permission!");
+            }
+        }
+        Err(e) => {
+            panic!("Expected network request to be blocked, but got successful response: {e}");
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fetch_with_different_host_still_denied() -> Result<()> {
+    let (manager, _tempdir) = setup_lifecycle_manager().await?;
+    let component_path = build_fetch_component().await?;
+
+    let (component_id, _) = manager
+        .load_component(&format!("file://{}", component_path.to_str().unwrap()))
+        .await?;
+
+    // Grant permission for example.com
+    manager
+        .grant_permission(
+            &component_id,
+            "network",
+            &serde_json::json!({"host": "example.com"}),
+        )
+        .await?;
+
+    let different_url = "https://httpbin.org/get";
+
+    let result = manager
+        .execute_component_call(
+            &component_id,
+            "fetch",
+            &serde_json::json!({"url": different_url}).to_string(),
+        )
+        .await;
+
+    match result {
+        Err(e) => {
+            panic!("Expected request to httpbin.org to be denied when only example.com is allowed, got: {e}");
+        }
+        Ok(response) => {
+            if response.contains("HttpRequestDenied") {
+                println!("✅ Request to unauthorized host properly blocked!");
+            } else {
+                panic!("Expected request to httpbin.org to be denied when only example.com is allowed, got: {response}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fetch_with_scheme_specific_permissions() -> Result<()> {
+    let (manager, _tempdir) = setup_lifecycle_manager().await?;
+    let component_path = build_fetch_component().await?;
+
+    let (component_id, _) = manager
+        .load_component(&format!("file://{}", component_path.to_str().unwrap()))
+        .await?;
+
+    // Grant permission for HTTPS example.com specifically
+    manager
+        .grant_permission(
+            &component_id,
+            "network",
+            &serde_json::json!({"host": "https://example.com"}),
+        )
+        .await?;
+
+    // Try HTTPS request - should work
+    let https_result = manager
+        .execute_component_call(
+            &component_id,
+            "fetch",
+            &serde_json::json!({"url": "https://example.com/"}).to_string(),
+        )
+        .await;
+
+    // HTTPS should succeed or fail for non-policy reasons
+    match https_result {
+        Ok(response) => {
+            println!("HTTPS fetch response: {response}");
+
+            if response.contains("HttpRequestDenied") {
+                panic!("HTTPS request should not be blocked by policy, got: {response}");
+            } else {
+                println!("✅ HTTPS request allowed as expected");
+            }
+        }
+        Err(e) => {
+            let error_msg = e.to_string();
+            assert!(
+                !error_msg.contains("denied")
+                    && !error_msg.contains("HttpRequestUriInvalid")
+                    && !error_msg.contains("HttpRequestDenied"),
+                "HTTPS request should not be denied by policy: {error_msg}"
+            );
+        }
+    }
+
+    // Try HTTP request to same host - should be denied
+    let http_result = manager
+        .execute_component_call(
+            &component_id,
+            "fetch",
+            &serde_json::json!({"url": "http://example.com/"}).to_string(),
+        )
+        .await;
+
+    match http_result {
+        Err(e) => {
+            let error_msg = e.to_string();
+            println!("Expected HTTP denial: {error_msg}");
+
+            assert!(
+                error_msg.contains("HttpRequestDenied"),
+                "Expected HTTP request to be denied when only HTTPS is allowed: {error_msg}"
+            );
+        }
+        Ok(response) => {
+            if response.contains("HttpRequestDenied") {
+                println!("✅ HTTP request properly blocked when only HTTPS allowed!");
+            } else {
+                panic!(
+                    "Expected HTTP request to be denied when only HTTPS is allowed, got: {response}"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/tests/transport_integration_test.rs
+++ b/tests/transport_integration_test.rs
@@ -1,5 +1,4 @@
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
@@ -21,6 +20,9 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
 use tokio::time::sleep;
 use wassette::LifecycleManager;
+
+mod common;
+use common::build_fetch_component;
 
 const DOCKER_REGISTRY_PORT: u16 = 5000;
 
@@ -57,35 +59,6 @@ async fn setup_registry() -> anyhow::Result<ContainerAsync<DockerRegistry>> {
         .start()
         .await
         .context("Failed to start docker registry")
-}
-
-async fn build_example_component() -> Result<PathBuf> {
-    let top_level =
-        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").context("CARGO_MANIFEST_DIR not set")?);
-
-    // NOTE: This assumes we are using linux path separators and hasn't been tested on windows.
-    let component_path =
-        top_level.join("examples/fetch-rs/target/wasm32-wasip2/release/fetch_rs.wasm");
-
-    let status = tokio::process::Command::new("cargo")
-        .current_dir(top_level.join("examples/fetch-rs"))
-        .args(["build", "--release", "--target", "wasm32-wasip2"])
-        .status()
-        .await
-        .context("Failed to execute cargo component build")?;
-
-    if !status.success() {
-        anyhow::bail!("Failed to compile fetch-rs component");
-    }
-
-    if !component_path.exists() {
-        anyhow::bail!(
-            "Component file not found after build: {}",
-            component_path.display()
-        );
-    }
-
-    Ok(component_path)
 }
 
 async fn cleanup_components(manager: &LifecycleManager) -> Result<()> {
@@ -134,7 +107,7 @@ async fn test_fetch_component_workflow() -> Result<()> {
         "Expected no components initially"
     );
 
-    let component_path = build_example_component().await?;
+    let component_path = build_fetch_component().await?;
 
     let (id, _) = manager
         .load_component(&format!("file://{}", component_path.to_str().unwrap()))
@@ -265,7 +238,7 @@ async fn test_load_component_from_https() -> Result<()> {
     let (manager, _tempdir) = setup_lifecycle_manager_with_client(http_client).await?;
 
     // Build the test component
-    let component_path = build_example_component().await?;
+    let component_path = build_fetch_component().await?;
 
     // Read the component bytes
     let wasm_bytes = tokio::fs::read(&component_path).await?;
@@ -299,7 +272,7 @@ async fn test_load_component_from_oci() -> Result<()> {
     let (manager, _tempdir) = setup_lifecycle_manager().await?;
 
     // Build the test component
-    let component_path = build_example_component().await?;
+    let component_path = build_fetch_component().await?;
 
     // Start OCI registry using testcontainers - skip if Docker is not available
     let container = match setup_registry().await {
@@ -310,7 +283,7 @@ async fn test_load_component_from_oci() -> Result<()> {
                 || error_msg.contains("docker client")
                 || error_msg.contains("Failed to start docker registry")
             {
-                println!("Skipping OCI test: Docker is not available - {}", error_msg);
+                println!("Skipping OCI test: Docker is not available - {error_msg}");
                 return Ok(());
             }
             return Err(e);
@@ -695,7 +668,7 @@ async fn test_default_stdio_transport() -> Result<()> {
 #[test(tokio::test)]
 async fn test_grant_permission_network_basic() -> Result<()> {
     let (manager, _tempdir) = setup_lifecycle_manager().await?;
-    let component_path = build_example_component().await?;
+    let component_path = build_fetch_component().await?;
 
     let (component_id, _) = manager
         .load_component(&format!("file://{}", component_path.to_str().unwrap()))


### PR DESCRIPTION
This commit enforces network policies by filtering outgoing HTTP requests based on list of allowed hosts defined in the policy file associated with the component.

This commit adds an integration test for the network policy enforcement.

Note that this commit implements a simplified version of the network policy enforcement. The policy is only enforced for exact host matches, no wildcard matching is supported.

The policy also does not enforce IP address matching.

