### PR TITLE
time-server-js: Remove disable all features to enable 'clocks'

### DIFF
--- a/examples/time-server-js/package.json
+++ b/examples/time-server-js/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "time.js",
   "scripts": {
-    "build": "jco componentize ./time.js --wit ./wit -d all -o ./time.wasm"
+    "build": "jco componentize ./time.js --wit ./wit -d http -d random -d stdio -o ./time.wasm"
   },
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Without the clocks feature, componentizeJs will stub the current time with the time of the build and the time will not be updated.

Should close #14 