### PR TITLE
fix(release): Fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,15 +64,15 @@ jobs:
       - name: Prepare binary (Unix)
         if: "!contains(matrix.target, 'windows')"
         run: |
-          cd target/${{ matrix.target }}/release
-          tar czvf ../../../${{ matrix.name }}.tar.gz wassette
+          cd target/release
+          tar czvf ../../${{ matrix.name }}.tar.gz wassette
           cd -
 
       - name: Prepare binary (Windows)
         if: contains(matrix.target, 'windows')
         run: |
-          cd target/${{ matrix.target }}/release
-          7z a ../../../${{ matrix.name }}.zip wassette.exe
+          cd target/release
+          7z a ../../${{ matrix.name }}.zip wassette.exe
           cd -
         shell: bash
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,10 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             name: wassette-linux-amd64
             runner: ubuntu-latest
-          - target: aarch64-unknown-linux-gnu
-            name: wassette-linux-arm
-            runner: ubuntu-24.04-arm
+          # Temporarily disabled - aarch64 runners not available for private repos
+          # - target: aarch64-unknown-linux-gnu
+          #   name: wassette-linux-arm
+          #   runner: ubuntu-24.04-arm
           # macOS targets
           - target: x86_64-apple-darwin
             name: wassette-darwin-amd64
@@ -40,9 +41,10 @@ jobs:
           - target: x86_64-pc-windows-msvc
             name: wassette-windows-amd64.exe
             runner: windows-latest
-          - target: aarch64-pc-windows-msvc
-            name: wassette-windows-arm64.exe
-            runner: windows-11-arm
+          # Temporarily disabled - aarch64 runners not available for private repos
+          # - target: aarch64-pc-windows-msvc
+          #   name: wassette-windows-arm64.exe
+          #   runner: windows-11-arm
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
             runner: ubuntu-latest
           # Temporarily disabled - aarch64 runners not available for private repos
           # - target: aarch64-unknown-linux-gnu
-          #   name: wassette-linux-arm
+          #   name: wassette-linux-arm64
           #   runner: ubuntu-24.04-arm
           # macOS targets
           - target: x86_64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
             name: wassette-darwin-amd64
             runner: macos-13
           - target: aarch64-apple-darwin
-            name: wassette-darwin-arm
+            name: wassette-darwin-arm64
             runner: macos-latest
           # Windows targets
           - target: x86_64-pc-windows-msvc


### PR DESCRIPTION
Add workflow_dispatch to make release pipeline easier to test
Temporarily disable aarch64 runners for Linux and Windows while repo is private
Fix target/release folder

Addresses #34 