### PR TITLE
fix: skip sccache for aarch64-windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Sccache Action
+        if: matrix.target != 'aarch64-pc-windows-msvc'
         uses: Mozilla-Actions/sccache-action@v0.0.9
 
       - name: Setup Rust toolchain


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/release.yml` file to conditionally exclude the `Sccache Action` step for the `aarch64-pc-windows-msvc` target. The reason being that the sccache binary does not the .zip file the action expect and is a bug in the 'Mozilla-Actions/sccache-action@v0.0.9' action.