### PR TITLE
fix: disable sccache via env vars for cargo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 jobs:
   build:
@@ -68,6 +66,9 @@ jobs:
 
       - name: Build release binary
         run: cargo build --release
+        env:
+          SCCACHE_GHA_ENABLED: ${{ matrix.target != 'aarch64-pc-windows-msvc' && 'true' || 'false' }}
+          RUSTC_WRAPPER: ${{ matrix.target != 'aarch64-pc-windows-msvc' && 'sccache' || '' }}
 
       - name: Extract version (Unix)
         if: "!contains(matrix.target, 'windows')"


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yml` file to refine the use of environment variables for the build process, specifically adjusting the configuration of `SCCACHE_GHA_ENABLED` and `RUSTC_WRAPPER` based on the target platform.