### PR TITLE
fix: remove optionality of server_peer in component handling functions

### DIFF
--- a/crates/mcp-server/src/components.rs
+++ b/crates/mcp-server/src/components.rs
@@ -14,15 +14,15 @@ pub(crate) async fn get_component_tools(lifecycle_manager: &LifecycleManager) ->
     debug!("Listing components");
     let component_ids = lifecycle_manager.list_components().await;
 
-    info!("Found {} components", component_ids.len());
+    info!(count = component_ids.len(), "Found components");
     let mut tools = Vec::new();
 
     for id in component_ids {
-        debug!("Getting component details for {}", id);
+        debug!(component_id = %id, "Getting component details");
         if let Some(schema) = lifecycle_manager.get_component_schema(&id).await {
             if let Some(arr) = schema.get("tools").and_then(|v| v.as_array()) {
                 let tool_count = arr.len();
-                debug!("Found {} tools in component {}", tool_count, id);
+                debug!(component_id = %id, tool_count, "Found tools in component");
                 for tool_json in arr {
                     if let Some(tool) = parse_tool_schema(tool_json) {
                         tools.push(tool);
@@ -31,7 +31,7 @@ pub(crate) async fn get_component_tools(lifecycle_manager: &LifecycleManager) ->
             }
         }
     }
-    info!("Total tools collected: {}", tools.len());
+    info!(total_tools = tools.len(), "Total tools collected");
     Ok(tools)
 }
 
@@ -47,7 +47,7 @@ pub(crate) async fn handle_load_component(
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow::anyhow!("Missing required argument: 'path'"))?;
 
-    info!("Loading component from path {}", path);
+    info!(path, "Loading component");
 
     let result = lifecycle_manager.load_component(path).await;
 
@@ -61,16 +61,16 @@ pub(crate) async fn handle_load_component(
             let contents = vec![Content::text(status_text)];
 
             info!(
-                "Notifying server peer about tool list change after loading component {}",
-                id
+                component_id = %id,
+                "Notifying server peer about tool list change after loading component"
             );
             // Notify the server peer about the tool list change
             if let Err(e) = server_peer.notify_tool_list_changed().await {
-                error!("Failed to send tool list change notification: {}", e);
+                error!(error = %e, "Failed to send tool list change notification");
             } else {
                 info!(
-                    "Sent tool list changed notification after loading component {}",
-                    id
+                    component_id = %id,
+                    "Sent tool list changed notification after loading component"
                 );
             }
 
@@ -80,7 +80,7 @@ pub(crate) async fn handle_load_component(
             })
         }
         Err(e) => {
-            error!("Failed to load component: {}", e);
+            error!(error = %e, path, "Failed to load component");
             Err(anyhow::anyhow!(
                 "Failed to load component: {}. Error: {}",
                 path,
@@ -103,7 +103,7 @@ pub(crate) async fn handle_unload_component(
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow::anyhow!("Missing 'id' in arguments"))?;
 
-    info!("Unloading component {}", id);
+    info!(component_id = %id, "Unloading component");
     lifecycle_manager.unload_component(id).await;
 
     let status_text = serde_json::to_string(&json!({
@@ -114,11 +114,11 @@ pub(crate) async fn handle_unload_component(
     let contents = vec![Content::text(status_text)];
 
     if let Err(e) = server_peer.notify_tool_list_changed().await {
-        error!("Failed to send tool list change notification: {}", e);
+        error!(error = %e, "Failed to send tool list change notification");
     } else {
         info!(
-            "Sent tool list changed notification after unloading component {}",
-            id
+            component_id = %id,
+            "Sent tool list changed notification after unloading component"
         );
     }
 
@@ -136,7 +136,7 @@ pub(crate) async fn handle_component_call(
     let args = extract_args_from_request(req)?;
 
     let method_name = req.name.to_string();
-    info!("Calling function {}", method_name);
+    info!(function_name = %method_name, "Calling function");
 
     let component_id = lifecycle_manager
         .get_component_id_for_tool(&method_name)
@@ -160,7 +160,7 @@ pub(crate) async fn handle_component_call(
             })
         }
         Err(e) => {
-            error!("Component call failed: {}", e);
+            error!(error = %e, "Component call failed");
             Err(anyhow::anyhow!(e.to_string()))
         }
     }
@@ -176,7 +176,7 @@ pub(crate) async fn handle_list_components(
 
     let components_info = stream::iter(component_ids)
         .map(|id| async move {
-            debug!("Getting component details for {}", id);
+            debug!(component_id = %id, "Getting component details");
             if let Some(schema) = lifecycle_manager.get_component_schema(&id).await {
                 let tools_count = schema
                     .get("tools")
@@ -241,7 +241,7 @@ fn parse_tool_schema(tool_json: &Value) -> Option<Tool> {
 
     let input_schema = tool_json.get("inputSchema").cloned().unwrap_or(json!({}));
 
-    debug!("Parsed tool schema for {}", name);
+    debug!(tool_name = %name, "Parsed tool schema");
 
     Some(Tool {
         name: Cow::Owned(name.to_string()),

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -35,7 +35,7 @@ pub async fn handle_tools_list(lifecycle_manager: &LifecycleManager) -> Result<V
 pub async fn handle_tools_call(
     req: CallToolRequestParam,
     lifecycle_manager: &LifecycleManager,
-    server_peer: Option<Peer<RoleServer>>,
+    server_peer: Peer<RoleServer>,
 ) -> Result<Value> {
     info!("Handling tool call");
 

--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -618,7 +618,7 @@ impl LifecycleManager {
     /// Returns the new ID and whether or not this component was replaced.
     #[instrument(skip(self))]
     pub async fn load_component(&self, uri: &str) -> Result<(String, LoadResult)> {
-        debug!("Loading component from URI: {}", uri);
+        debug!(uri, "Loading component");
 
         let downloaded_resource =
             load_resource::<ComponentResource>(uri, &self.oci_client, &self.http_client).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,15 +73,11 @@ fn get_component_dir() -> PathBuf {
 #[derive(Clone)]
 pub struct McpServer {
     lifecycle_manager: LifecycleManager,
-    peer: Option<rmcp::service::Peer<RoleServer>>,
 }
 
 impl McpServer {
     pub fn new(lifecycle_manager: LifecycleManager) -> Self {
-        Self {
-            lifecycle_manager,
-            peer: None,
-        }
+        Self { lifecycle_manager }
     }
 }
 
@@ -114,9 +110,9 @@ Key points:
     fn call_tool<'a>(
         &'a self,
         params: CallToolRequestParam,
-        _ctx: RequestContext<RoleServer>,
+        ctx: RequestContext<RoleServer>,
     ) -> Pin<Box<dyn Future<Output = Result<CallToolResult, ErrorData>> + Send + 'a>> {
-        let peer_clone = self.peer.clone();
+        let peer_clone = ctx.peer.clone();
 
         Box::pin(async move {
             let result = handle_tools_call(params, &self.lifecycle_manager, peer_clone).await;


### PR DESCRIPTION
This allows the `load-component` and `unload-component` to notify the client that the list of tools are changed