### PR TITLE
feat(wassette): unload-component now should delete files on Disk

### DIFF
--- a/crates/mcp-server/src/components.rs
+++ b/crates/mcp-server/src/components.rs
@@ -101,30 +101,48 @@ pub(crate) async fn handle_unload_component(
         .ok_or_else(|| anyhow::anyhow!("Missing 'id' in arguments"))?;
 
     info!("Unloading component {}", id);
-    lifecycle_manager.unload_component(id).await;
 
-    let status_text = serde_json::to_string(&json!({
-        "status": "component unloaded",
-        "id": id
-    }))?;
+    match lifecycle_manager.unload_component(id).await {
+        Ok(()) => {
+            let status_text = serde_json::to_string(&json!({
+                "status": "component unloaded successfully",
+                "id": id
+            }))?;
 
-    let contents = vec![Content::text(status_text)];
+            let contents = vec![Content::text(status_text)];
 
-    if let Some(peer) = server_peer {
-        if let Err(e) = peer.notify_tool_list_changed().await {
-            error!("Failed to send tool list change notification: {}", e);
-        } else {
-            info!(
-                "Sent tool list changed notification after unloading component {}",
-                id
-            );
+            if let Some(peer) = server_peer {
+                if let Err(e) = peer.notify_tool_list_changed().await {
+                    error!("Failed to send tool list change notification: {}", e);
+                } else {
+                    info!(
+                        "Sent tool list changed notification after unloading component {}",
+                        id
+                    );
+                }
+            }
+
+            Ok(CallToolResult {
+                content: contents,
+                is_error: None,
+            })
+        }
+        Err(e) => {
+            error!("Failed to unload component {}: {}", id, e);
+            let error_text = serde_json::to_string(&json!({
+                "status": "error",
+                "message": format!("Failed to unload component: {}", e),
+                "id": id
+            }))?;
+
+            let contents = vec![Content::text(error_text)];
+
+            Ok(CallToolResult {
+                content: contents,
+                is_error: Some(true),
+            })
         }
     }
-
-    Ok(CallToolResult {
-        content: contents,
-        is_error: None,
-    })
 }
 
 #[instrument(skip(lifecycle_manager))]

--- a/tests/file_integration_test.rs
+++ b/tests/file_integration_test.rs
@@ -14,7 +14,7 @@ use common::build_filesystem_component;
 async fn cleanup_components(manager: &LifecycleManager) -> Result<()> {
     let component_ids = manager.list_components().await;
     for id in component_ids {
-        manager.unload_component(&id).await;
+        manager.unload_component(&id).await?;
     }
     Ok(())
 }

--- a/tests/grant_permission_integration_test.rs
+++ b/tests/grant_permission_integration_test.rs
@@ -11,7 +11,7 @@ use common::build_fetch_component;
 async fn cleanup_components(manager: &LifecycleManager) -> Result<()> {
     let component_ids = manager.list_components().await;
     for id in component_ids {
-        manager.unload_component(&id).await;
+        manager.unload_component(&id).await?;
     }
     Ok(())
 }

--- a/tests/transport_integration_test.rs
+++ b/tests/transport_integration_test.rs
@@ -64,7 +64,7 @@ async fn setup_registry() -> anyhow::Result<ContainerAsync<DockerRegistry>> {
 async fn cleanup_components(manager: &LifecycleManager) -> Result<()> {
     let component_ids = manager.list_components().await;
     for id in component_ids {
-        manager.unload_component(&id).await;
+        manager.unload_component(&id).await?;
     }
     Ok(())
 }


### PR DESCRIPTION
Currently, unload-component API only deletes the runtime state of the Wassette server, but it doesn not touch the files on the Disk. There is a separate API called uninstall-component. However, this is not a symmetric to load-component that users would expect. This commit deletes the unused uninstall-component function and modifies the unload-componnet API to be able to delete the wasm and co-located policy files on Disk.

Signed-off-by: Jiaxiao Zhou <duibao55328@gmail.com>
