### PR TITLE
docs: release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,7 @@ jobs:
 
             ### Linux
             - [AMD64 (tar.gz)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/wassette_${{ steps.version.outputs.version }}_linux_amd64.tar.gz)
+            - [ARM64 (tar.gz)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/wassette_${{ steps.version.outputs.version }}_linux_arm64.tar.gz)
 
             ### macOS (Darwin)
             - [AMD64/Intel (tar.gz)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/wassette_${{ steps.version.outputs.version }}_darwin_amd64.tar.gz)
@@ -165,6 +166,7 @@ jobs:
 
             ### Windows
             - [AMD64 (zip)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/wassette_${{ steps.version.outputs.version }}_windows_amd64.zip)
+            - [ARM64 (zip)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/wassette_${{ steps.version.outputs.version }}_windows_arm64.zip)
 
             ## Install
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,38 @@
+# Release Process
+
+This document desribes the process for releasing new versions of the Wassette project.
+
+## Release.yml overview
+
+The release process is automated using GitHub Actions, specifically the [`release.yml`](.github/workflows/release.yml) workflow. This workflow is triggered when a new tag is pushed to the repository. Once triggered, the workflow uses a matrix to compile `wassette` for different platforms on native runners and uses `sccache` to speed up the compilation process by caching previous builds. The compiled binaries are then uploaded as artifacts to the release.
+
+## Release Versioning
+
+Wassette uses semantic versioning. All releases follow the format `vX.Y.Z`, where X is the major version, Y is the minor version, and Z is the patch version.
+
+## Tagging Strategy
+
+- All release tags are prefixed with v, e.g., v0.10.0.
+- Tags are created on the default branch (typically main), or on a release branch when applicable.
+- Patch releases increment the Z portion, e.g., v0.6.1 → v0.6.2.
+- Minor releases increment the Y portion, e.g., v0.9.0 → v0.10.0.
+
+## Steps to Cut a Release
+
+1. **Prepare the Release branch**:
+
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+
+1. **Create a new tag**: To initiate a release, create a new tag in the Git repository. This can be done using the following command:
+
+   ```bash
+   git tag <tag_name> # e.g., v0.1.0
+   git push origin <tag_name> # e.g., v0.1.0
+   ```
+
+1. **Trigger the release workflow**: Once the tag is pushed, the `release.yml` workflow will be triggered automatically. You can monitor the progress of the workflow in the "Actions" tab of the GitHub repository.
+
+1. **Download the compiled binaries**: After the workflow completes successfully, the compiled binaries for each platform will be available for download in the "[Releases](https://github.com/microsoft/wassette/releases)" section of the GitHub repository.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Process
 
-This document desribes the process for releasing new versions of the Wassette project.
+This document describes the process for releasing new versions of the Wassette project.
 
 ## Release.yml overview
 


### PR DESCRIPTION
This pull request adds a new release process documentation for the Wassette project. The document outlines how to perform releases using GitHub Actions, describes the versioning and tagging strategy, and provides step-by-step instructions for cutting a new release.

Documentation improvements:

* Added a new `RELEASE.md` file that details the automated release process, versioning scheme, tagging strategy, and step-by-step instructions for releasing new versions using GitHub Actions and the `release.yml` workflow.