### PR TITLE
Fix missing docs

### DIFF
--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+//! A security-oriented runtime that runs WebAssembly Components via MCP
+
+#![warn(missing_docs)]
+
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -40,12 +44,16 @@ const DOWNLOADS_DIR: &str = "downloads";
 /// Granular permission rule types
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PermissionRule {
+    /// Network access permission
     #[serde(rename = "network")]
     Network(NetworkPermission),
+    /// File system storage permission
     #[serde(rename = "storage")]
     Storage(StoragePermission),
+    /// Environment variable access permission
     #[serde(rename = "environment")]
     Environment(EnvironmentPermission),
+    /// Custom permission with arbitrary data
     #[serde(rename = "custom")]
     Custom(String, serde_json::Value),
 }
@@ -53,8 +61,11 @@ pub enum PermissionRule {
 /// Permission grant request structure
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PermissionGrantRequest {
+    /// The ID of the component requesting permission
     pub component_id: String,
+    /// The type of permission being requested
     pub permission_type: String,
+    /// Additional details specific to the permission type
     pub details: serde_json::Value,
 }
 
@@ -206,17 +217,25 @@ impl ComponentRegistry {
     }
 }
 
+/// Registry for storing policy templates associated with components
 #[derive(Default)]
 struct PolicyRegistry {
+    /// Maps component IDs to their associated policy templates
     component_policies: HashMap<String, Arc<WasiStateTemplate>>,
 }
 
+/// Information about a policy attached to a component
 #[derive(Debug, Clone)]
 pub struct PolicyInfo {
+    /// Unique identifier for the policy
     pub policy_id: String,
+    /// The original URI where the policy was loaded from
     pub source_uri: String,
+    /// Local filesystem path where the policy is stored
     pub local_path: PathBuf,
+    /// ID of the component this policy is attached to
     pub component_id: String,
+    /// Timestamp when the policy was created/attached
     pub created_at: std::time::SystemTime,
 }
 
@@ -761,6 +780,7 @@ impl LifecycleManager {
         self.components.read().await.get(component_id).cloned()
     }
 
+    /// Lists all loaded components by their IDs
     #[instrument(skip(self))]
     pub async fn list_components(&self) -> Vec<String> {
         self.components.read().await.keys().cloned().collect()

--- a/crates/wassette/src/wasistate.rs
+++ b/crates/wassette/src/wasistate.rs
@@ -28,12 +28,19 @@ pub struct NetworkPermissions {
 /// this includes the wasmtime_wasi, wasmtime_wasi_config and wasmtime_wasi_http states
 #[derive(Clone)]
 pub struct WasiStateTemplate {
+    /// Whether to allow stdout access
     pub allow_stdout: bool,
+    /// Whether to allow stderr access
     pub allow_stderr: bool,
+    /// Whether to allow command line arguments access
     pub allow_args: bool,
+    /// Network permissions configuration
     pub network_perms: NetworkPermissions,
+    /// Configuration variables for wasmtime_wasi_config
     pub config_vars: HashMap<String, String>, // wamstime_wasi_config specific state
+    /// Preopened directories for filesystem access
     pub preopened_dirs: Vec<PreopenedDir>,
+    /// Allowed network hosts for HTTP requests
     pub allowed_hosts: HashSet<String>, // allowed network hosts for HTTP requests
 }
 

--- a/crates/wassette/src/wasistate.rs
+++ b/crates/wassette/src/wasistate.rs
@@ -37,11 +37,11 @@ pub struct WasiStateTemplate {
     /// Network permissions configuration
     pub network_perms: NetworkPermissions,
     /// Configuration variables for wasmtime_wasi_config
-    pub config_vars: HashMap<String, String>, // wamstime_wasi_config specific state
+    pub config_vars: HashMap<String, String>,
     /// Preopened directories for filesystem access
     pub preopened_dirs: Vec<PreopenedDir>,
     /// Allowed network hosts for HTTP requests
-    pub allowed_hosts: HashSet<String>, // allowed network hosts for HTTP requests
+    pub allowed_hosts: HashSet<String>,
 }
 
 impl Default for WasiStateTemplate {

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
+    /// Begin handling requests over the specified protocol.
     Serve {
         #[arg(long, default_value_t = get_component_dir().into_os_string().into_string().unwrap())]
         plugin_dir: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+//! The main `wassette(1)` command.
+
+#![warn(missing_docs)]
+
 use std::env;
 use std::future::Future;
 use std::path::PathBuf;
@@ -73,12 +77,17 @@ fn get_component_dir() -> PathBuf {
     }
 }
 
+/// A security-oriented runtime that runs WebAssembly Components via MCP.
 #[derive(Clone)]
 pub struct McpServer {
     lifecycle_manager: LifecycleManager,
 }
 
 impl McpServer {
+    /// Creates a new MCP server instance with the given lifecycle manager.
+    ///
+    /// # Arguments
+    /// * `lifecycle_manager` - The lifecycle manager for handling component operations
     pub fn new(lifecycle_manager: LifecycleManager) -> Self {
         Self { lifecycle_manager }
     }


### PR DESCRIPTION
This PR adds a number of additional comments, mostly auto-generated. Most notably though: this documents the `serve` subcommand, which is important for people running the commands from the command line. With this PR it now looks like this:

```text
Usage: wassette <COMMAND>

Commands:
  serve  Begin handling requests over the specified protocol
  help   Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```