### PR TITLE
feat: add Homebrew formula and installation documentation for Wassette

### DIFF
--- a/Formula/wassette.rb
+++ b/Formula/wassette.rb
@@ -1,0 +1,36 @@
+class Wassette < Formula
+  desc "Wassette: A security-oriented runtime that runs WebAssembly Components via MCP"
+  homepage "https://github.com/microsoft/wassette"
+  # Change this to install a different version of wassette.
+  # The release tag in GitHub must exist with a 'v' prefix (e.g., v0.1.0).
+  version "0.2.0"
+
+  on_macos do
+    if Hardware::CPU.intel?
+      url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_darwin_amd64.tar.gz"
+      sha256 "4b2624fa6060be45b5b7ab97d45bbe387961653e33edb9fd1fa1bd7678172ad7"
+    else
+      url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_darwin_arm64.tar.gz"
+      sha256 "67aaaea5be1ed8d56be2a11de5e6eb1e66336fcb7c6fdf3f0df82f9ba6b62642"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.intel?
+      url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_linux_amd64.tar.gz"
+      sha256 "4d92aba7d31bda7b0dad399f7885a452473440ac20e9d1f764a4e199b4bb387b"
+    else
+      url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_linux_arm64.tar.gz"
+      sha256 "556560a34d208f21ae6b733a26a3d5d1898cb4aea0989abd4762b38bea717e9b"
+    end
+  end
+
+  def install
+    bin.install "wassette"
+  end
+
+  test do
+    # Check if the installed binary's version matches the formula's version
+    assert_match "wassette-mcp-server #{version}", shell_output("#{bin}/wassette --version")
+  end
+end

--- a/Formula/wassette.rb
+++ b/Formula/wassette.rb
@@ -8,20 +8,20 @@ class Wassette < Formula
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_darwin_amd64.tar.gz"
-      sha256 "4b2624fa6060be45b5b7ab97d45bbe387961653e33edb9fd1fa1bd7678172ad7"
+      sha256 "29484bc445907ced569b22adf1c2ec8a244c55818a3a7e26ed49af7ba1203be2"
     else
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_darwin_arm64.tar.gz"
-      sha256 "67aaaea5be1ed8d56be2a11de5e6eb1e66336fcb7c6fdf3f0df82f9ba6b62642"
+      sha256 "9ce7611910b430f5f4a631d420743ecc831883178e72309ddc21269efcf1a2c6"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_linux_amd64.tar.gz"
-      sha256 "4d92aba7d31bda7b0dad399f7885a452473440ac20e9d1f764a4e199b4bb387b"
+      sha256 "ee75388f649244a6fb1d15b864a5551e761213315d1bd4cf710b29b17e4f5435"
     else
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_linux_arm64.tar.gz"
-      sha256 "556560a34d208f21ae6b733a26a3d5d1898cb4aea0989abd4762b38bea717e9b"
+      sha256 "f0461a51b13b24acda002b42df08846d6d001d021d3fd91ea316521d4f417ecf"
     end
   end
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ For Linux and macOS, you can install Wassette using the provided install script:
 curl -fsSL https://raw.githubusercontent.com/microsoft/wassette/main/install.sh | bash
 ```
 
-This will detect your platform and install the latest `wassette` binary to your `$PATH`. For Windows, you can download the latest release from the [GitHub Releases page][Releases]
+This will detect your platform and install the latest `wassette` binary to your `$PATH`. 
+
+We also provide a [Homebrew formula for macOS and Linux](./docs/homebrew.md).
+
+For Windows, you can download the latest release from the [GitHub Releases page][Releases]
 
 ## Using Wassette
 

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -1,0 +1,35 @@
+# Install Wassette with Homebrew
+
+This guide explains how to install `wassette` using Homebrew.
+
+This uses the Formula in `Formula/wassette.rb`, which is setup to download and install the latest release of `wassette` from GitHub.
+
+You must have Homebrew installed on your macOS or Linux system. If you don't, you can install it by following the instructions on the [official Homebrew website](https://brew.sh/).
+
+## Installation
+
+You can install `wassette` with a single command:
+
+```bash
+brew tap microsoft/wassette https://github.com/microsoft/wassette
+brew install wassette
+```
+
+This command will automatically tap the `microsoft/wassette` repository and install the `wassette` formula.
+
+## Verifying the Installation
+
+To make sure everything worked, you can run:
+
+```bash
+wassette --version
+```
+
+## Upgrading
+
+To upgrade `wassette` to the latest version, first update Homebrew's package list and then upgrade the `wassette` package.
+
+```bash
+brew update
+brew upgrade wassette
+```


### PR DESCRIPTION
This adds a homebrew formula, pinned to the v0.2.0 release, and accompanying docs at docs/homebrew.md.

We should look at updating this automatically on each release.

Addresses #45 