### PR TITLE
docs: update README.md for all examples/

### DIFF
--- a/examples/eval-py/README.md
+++ b/examples/eval-py/README.md
@@ -1,0 +1,21 @@
+# Python Evaluation Example
+
+This example demonstrates how to evaluate a Python expression using a Wassette component.
+
+For more information on installing Wassette, please see the [installation instructions](https://github.com/microsoft/wassette?tab=readme-ov-file#installation).
+
+## Usage
+
+To use this component, load it from the OCI registry and provide a Python expression to evaluate.
+
+**Load the component:**
+```
+Please load the component from oci://ghcr.io/microsoft/eval-py:latest
+```
+
+**Evaluate an expression:**
+```
+Please evaluate the python expression '2 + 2'
+```
+
+The source code for this example can be found in [main.py](main.py).

--- a/examples/eval-py/README.md
+++ b/examples/eval-py/README.md
@@ -18,4 +18,4 @@ Please load the component from oci://ghcr.io/microsoft/eval-py:latest
 Please evaluate the python expression '2 + 2'
 ```
 
-The source code for this example can be found in [main.py](main.py).
+The source code for this example can be found in [`main.py`](main.py).

--- a/examples/fetch-rs/README.md
+++ b/examples/fetch-rs/README.md
@@ -1,40 +1,26 @@
-# Fetch-rs Example
+# Fetch Example (Rust)
 
-This example demonstrates the use of the `wassette` runtime to interact with HTTP APIs as a WebAssembly (Wasm) component using Rust. It showcases how to define and enforce permissions for accessing network resources using a policy file.
+This example demonstrates how to fetch content from a URL using a Wassette component written in Rust.
 
-## Tools
+For more information on installing Wassette, please see the [installation instructions](https://github.com/microsoft/wassette?tab=readme-ov-file#installation).
 
-- **Fetch URL**: Fetches the contents of a specified URL using HTTP GET.
+## Usage
 
-## Setup
+To use this component, load it from the OCI registry and provide a URL to fetch.
 
-1. **Add MCP Server to VS Code**:
+**Load the component:**
 
-   - Open your `settings.json` file in VS Code.
-   - Add the MCP server configuration under the `mcp.servers` section. Example:
-     ```json
-     "mcp": {
-       "servers": {
-         "wassette": {
-           "type": "sse",
-           "url": "http://127.0.0.1:9001/sse"
-         }
-       }
-     }
-     ```
+```
+Please load the component from oci://ghcr.io/microsoft/fetch-rs:latest
+```
 
-2. **Start the MCP Server**:
+**Fetch content:**
 
-   - Use the `Justfile` to start the server with the appropriate policy file:
-     ```bash
-     just run-fetch-rs
-     ```
+```
+Please fetch the content of https://example.com
+```
 
-3. **Run a Fetch Tool**:
-
-   - Use the agent in VS Code to execute a fetch tool, such as `fetch_url`. Ensure the tool is configured to use the MCP server.
-
-## Policy File
+## Policy
 
 By default, WebAssembly (Wasm) components do not have any access to the host machine or network. The `policy.yaml` file is used to explicitly define what network resources are made available to the component. This ensures that the component can only access the resources that are explicitly allowed.
 
@@ -48,3 +34,5 @@ permissions:
     allow:
       - host: "https://rss.nytimes.com/"
 ```
+
+The source code for this example can be found in [`src/lib.rs`](src/lib.rs).

--- a/examples/filesystem-rs/README.md
+++ b/examples/filesystem-rs/README.md
@@ -1,45 +1,24 @@
-# Filesystem Example
+# Filesystem Example (Rust)
 
-This example demonstrates the use of the `wassette` runtime to interact with the filesystem as a WebAssembly (Wasm) component. It showcases how to define and enforce permissions for accessing files and directories using a policy file.
+This example demonstrates how to interact with the filesystem using a Wassette component written in Rust.
 
-## Tools
+For more information on installing Wassette, please see the [installation instructions](https://github.com/microsoft/wassette?tab=readme-ov-file#installation).
 
-- **Read File**: Read the contents of a file within allowed directories.
-- **List Directory**: List the contents of a directory, distinguishing between files and directories.
-- **Search Files**: Recursively search for files matching a pattern.
-- **Get File Info**: Retrieve metadata about a file or directory.
+## Usage
 
-## Setup
+To use this component, load it from the OCI registry and provide a file path to read.
 
-1. **Add MCP Server to VS Code**:
+**Load the component:**
+```
+Please load the component from oci://ghcr.io/microsoft/filesystem-rs:latest
+```
 
-   - Open your `settings.json` file in VS Code.
-   - Add the MCP server configuration under the `mcp.servers` section. Example:
-     ```json
-     "mcp": {
-       "servers": {
-         "wassette": {
-           "type": "sse",
-           "url": "http://127.0.0.1:9001/sse"
-         }
-       }
-     }
-     ```
+**Get file content:**
+```
+Please get the content of the file examples/filesystem-rs/README.md
+```
 
-2. **Start the MCP Server**:
-
-   - Use the `Justfile` to start the server with the appropriate policy file:
-     ```bash
-     just run-filesystems
-     ```
-
-3. **Run a Filesystem Tool**:
-
-   - Use the agent in VS Code to execute a filesystem tool, such as `read_file` or `get_file_into`. Ensure the tool is configured to use the MCP server.
-
-   ![alt text](get_file_into.png)
-
-## Policy File
+## Policy
 
 By default, WebAssembly (Wasm) components do not have any access to the host machine. The `policy.yaml` file is used to explicitly define what paths and permissions are made available to the component through the WebAssembly System Interface (WASI). This ensures that the component can only access the resources that are explicitly allowed.
 
@@ -58,3 +37,5 @@ permissions:
       - uri: "fs:///"
         access: ["read"]
 ```
+
+The source code for this example can be found in [`src/lib.rs`](src/lib.rs).

--- a/examples/get-weather-js/README.md
+++ b/examples/get-weather-js/README.md
@@ -1,50 +1,32 @@
-# Get Weather Example
+# Get Weather Example (JavaScript)
 
-This example demonstrates the use of the `wassette` runtime to interact with a weather API as a WebAssembly (Wasm) component. It showcases how to define and enforce permissions for accessing network resources and environment variables using a policy file.
+This example demonstrates how to get the weather for a given location using a Wassette component written in JavaScript.
 
-## Tools
+For more information on installing Wassette, please see the [installation instructions](https://github.com/microsoft/wassette?tab=readme-ov-file#installation).
 
-- **Get Weather**: Fetches the current weather for a specified city using the OpenWeather API.
+## Usage
 
-## Setup
+To use this component, you will need an API key from [OpenWeather](https://openweathermap.org/api). Export the API key as an environment variable:
 
-1. **Add MCP Server to VS Code**:
+```bash
+export OPENWEATHER_API_KEY="your_api_key_here"
+```
 
-   - Open your `settings.json` file in VS Code.
-   - Add the MCP server configuration under the `mcp.servers` section. Example:
-     ```json
-     "mcp": {
-       "servers": {
-         "wassette": {
-           "type": "sse",
-           "url": "http://127.0.0.1:9001/sse"
-         }
-       }
-     }
-     ```
+Then, load the component from the OCI registry and provide a latitude and longitude.
 
-2. **Set the OpenWeather API Key**:
+**Load the component:**
 
-   - Obtain an API key from [OpenWeather](https://openweathermap.org/api).
-   - Export the API key as an environment variable:
-     ```bash
-     export OPENWEATHER_API_KEY="your_api_key_here"
-     ```
+```
+Please load the component from oci://ghcr.io/microsoft/get-weather-js:latest
+```
 
-3. **Start the MCP Server**:
+**Get the weather:**
 
-   - Use the `Justfile` to start the server with the appropriate policy file:
-     ```bash
-     just run-get-weather
-     ```
+```
+get the weather for latitude 43.65 and longitude -79.38
+```
 
-4. **Run the Weather Tool**:
-
-   - Use the agent in VS Code to execute the weather tool and fetch the weather for a city with a prompt like "Get weather for Omaha".
-
-   ![Weather Tool Screenshot](get-weather.png)
-
-## Policy File
+## Policy
 
 By default, WebAssembly (Wasm) components do not have any access to the host machine or network. The `policy.yaml` file is used to explicitly define what network resources and environment variables are made available to the component. This ensures that the component can only access the resources that are explicitly allowed.
 
@@ -61,3 +43,5 @@ permissions:
     allow:
       - key: "OPENWEATHER_API_KEY"
 ```
+
+The source code for this example can be found in [`weather.js`](weather.js).

--- a/examples/gomodule-go/README.md
+++ b/examples/gomodule-go/README.md
@@ -1,10 +1,21 @@
-# gomodule Example
+# Go Module Example (Go)
 
-This example demonstrates the use of the `wassette` runtime to interact with the Go module server as a WebAssembly (Wasm) component. It showcases how to define and enforce permissions for accessing network resources and environment variables using a policy file.
+This example demonstrates how to get information about Go modules using a Wassette component written in Go.
 
-## Tools
+For more information on installing Wassette, please see the [installation instructions](https://github.com/microsoft/wassette?tab=readme-ov-file#installation).
 
-- **Get Latest Version**: Get the latest version of a Go module.
-- **Get Module Info**: Get detailed information about a Go module.
+## Usage
 
-![alt text](gomodule-info.png)
+To use this component, load it from the OCI registry and provide a Go module path.
+
+**Load the component:**
+```
+Please load the component from oci://ghcr.io/microsoft/gomodule-go:latest
+```
+
+**Get module information:**
+```
+get the latest versions for the go module urfave/cli
+```
+
+The source code for this example can be found in [`main.go`](main.go).

--- a/examples/time-server-js/README.md
+++ b/examples/time-server-js/README.md
@@ -1,0 +1,21 @@
+# Time Server Example (JavaScript)
+
+This example demonstrates how to get the current time using a Wassette component written in JavaScript.
+
+For more information on installing Wassette, please see the [installation instructions](https://github.com/microsoft/wassette?tab=readme-ov-file#installation).
+
+## Usage
+
+To use this component, load it from the OCI registry and ask for the current time.
+
+**Load the component:**
+```
+Please load the component from oci://ghcr.io/microsoft/time-server-js:latest
+```
+
+**Get the current time:**
+```
+What is the current time?
+```
+
+The source code for this example can be found in [`time.js`](time.js).


### PR DESCRIPTION
This pull request adds and updates the `README.md` files for several examples to include instructions on how to load and use the components from the OCI registry.

Key changes include:

- **New `README.md` files:**
    - `examples/eval-py/README.md`
    - `examples/time-server-js/README.md`

- **Updated `README.md` files:**
    - `examples/fetch-rs/README.md`
    - `examples/filesystem-rs/README.md`
    - `examples/get-weather-js/README.md`
    - `examples/gomodule-go/README.md`

The updated documentation provides clear and consistent instructions for users, including the specific commands to load components from `ghcr.io` and execute their respective functions. This improves the usability and discoverability of the examples.
