### PR TITLE
feat(ci): Add caching to the rust build

### DIFF
--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -1,0 +1,20 @@
+name: Setup rust cache
+
+runs:
+  using: composite
+  steps:
+    - name: Get rust version
+      run: echo "RUST_VERSION=$(rustc --version | awk '{print $2}')" >> $GITHUB_ENV
+      shell: bash
+    - name: Get Cargo.lock SHA 
+      shell: bash
+      run: |
+        if command -v sha256sum >/dev/null 2>&1; then
+          echo "CARGO_LOCK_SHA=$(sha256sum Cargo.lock | awk '{print $1}')" >> $GITHUB_ENV
+        else
+          echo "CARGO_LOCK_SHA=$(shasum -a 256 Cargo.lock | awk '{print $1}')" >> $GITHUB_ENV
+        fi
+    - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+      with:
+        shared-key: "wassette-${{ env.RUST_VERSION }}-${{ env.CARGO_LOCK_SHA }}"
+        

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,7 @@ jobs:
     - run: 
         # needed to run rustfmt in nightly toolchain
         rustup toolchain install nightly --component rustfmt
+    - uses: ./.github/actions/rust-cache
     - name: Run fmt
       run: cargo +nightly fmt --all -- --check
     - name: Run Clippy
@@ -49,6 +50,7 @@ jobs:
       shell: bash
     - uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1.13.0
     - run: rustup target add wasm32-wasip2
+    - uses: ./.github/actions/rust-cache
     - name: Build
       run: just build
     - name: Run tests

--- a/crates/component2json/src/lib.rs
+++ b/crates/component2json/src/lib.rs
@@ -1789,8 +1789,7 @@ mod tests {
         for tool_name in test_names {
             assert!(
                 validate_tool_name(tool_name).is_ok(),
-                "Tool name '{}' should be MCP compliant",
-                tool_name
+                "Tool name '{tool_name}' should be MCP compliant"
             );
         }
     }

--- a/crates/policy/src/parser.rs
+++ b/crates/policy/src/parser.rs
@@ -163,20 +163,21 @@ invalid: yaml: content
 
         let result = PolicyParser::parse_str(yaml_content);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().len() > 0);
+        assert!(!result.unwrap_err().to_string().is_empty());
     }
 
     #[test]
     fn test_round_trip_serialization() {
-        let mut permissions = Permissions::default();
-        permissions.storage = Some(PermissionList {
-            allow: Some(vec![StoragePermission {
-                uri: "fs://work/agent/**".to_string(),
-                access: vec![AccessType::Read, AccessType::Write],
-            }]),
-            deny: None,
-        });
-
+        let permissions = Permissions {
+            storage: Some(PermissionList {
+                allow: Some(vec![StoragePermission {
+                    uri: "fs://work/agent/**".to_string(),
+                    access: vec![AccessType::Read, AccessType::Write],
+                }]),
+                deny: None,
+            }),
+            ..Default::default()
+        };
         let original = PolicyDocument {
             version: "1.0".to_string(),
             description: Some("Test policy".to_string()),
@@ -493,8 +494,7 @@ permissions: {}
             let reparsed_policy = PolicyParser::parse_str(&yaml_string).unwrap();
             assert_eq!(
                 original_policy, reparsed_policy,
-                "Round trip failed for {}",
-                file_path
+                "Round trip failed for {file_path}",
             );
         }
     }
@@ -517,7 +517,7 @@ permissions: {}
         for file_path in &test_files {
             let policy = PolicyParser::parse_file(file_path).unwrap();
             policy.validate().unwrap_or_else(|e| {
-                panic!("Validation failed for {}: {}", file_path, e);
+                panic!("Validation failed for {file_path}: {e}");
             });
         }
     }

--- a/crates/policy/src/types.rs
+++ b/crates/policy/src/types.rs
@@ -315,41 +315,47 @@ mod tests {
 
     #[test]
     fn test_storage_permission_validation() {
-        let mut permissions = Permissions::default();
-        permissions.storage = Some(PermissionList {
-            allow: Some(vec![StoragePermission {
-                uri: "".to_string(),
-                access: vec![AccessType::Read],
-            }]),
-            deny: None,
-        });
+        let permissions = Permissions {
+            storage: Some(PermissionList {
+                allow: Some(vec![StoragePermission {
+                    uri: "".to_string(),
+                    access: vec![AccessType::Read],
+                }]),
+                deny: None,
+            }),
+            ..Default::default()
+        };
 
         assert!(permissions.validate().is_err());
     }
 
     #[test]
     fn test_network_cidr_validation() {
-        let mut permissions = Permissions::default();
-        permissions.network = Some(PermissionList {
-            allow: Some(vec![NetworkPermission::Cidr(NetworkCidrPermission {
-                cidr: "invalid-cidr".to_string(), // Invalid CIDR format
-            })]),
-            deny: None,
-        });
+        let permissions = Permissions {
+            network: Some(PermissionList {
+                allow: Some(vec![NetworkPermission::Cidr(NetworkCidrPermission {
+                    cidr: "invalid-cidr".to_string(), // Invalid CIDR format
+                })]),
+                deny: None,
+            }),
+            ..Default::default()
+        };
 
         assert!(permissions.validate().is_err());
     }
 
     #[test]
     fn test_valid_permissions() {
-        let mut permissions = Permissions::default();
-        permissions.storage = Some(PermissionList {
-            allow: Some(vec![StoragePermission {
-                uri: "fs://work/agent/**".to_string(),
-                access: vec![AccessType::Read, AccessType::Write],
-            }]),
-            deny: None,
-        });
+        let permissions = Permissions {
+            storage: Some(PermissionList {
+                allow: Some(vec![StoragePermission {
+                    uri: "fs://work/agent/**".to_string(),
+                    access: vec![AccessType::Read, AccessType::Write],
+                }]),
+                deny: None,
+            }),
+            ..Default::default()
+        };
 
         assert!(permissions.validate().is_ok());
     }
@@ -402,68 +408,69 @@ mod tests {
 
     #[test]
     fn test_comprehensive_wildcard_validation() {
-        let mut permissions = Permissions::default();
-
-        permissions.storage = Some(PermissionList {
-            allow: Some(vec![
-                StoragePermission {
-                    uri: "fs://work/agent/**".to_string(),
-                    access: vec![AccessType::Read, AccessType::Write],
-                },
-                StoragePermission {
-                    uri: "fs://work/*/temp".to_string(),
-                    access: vec![AccessType::Read],
-                },
-            ]),
-            deny: Some(vec![StoragePermission {
-                uri: "fs://work/agent/secret/*".to_string(),
-                access: vec![AccessType::Write],
-            }]),
-        });
-
-        permissions.network = Some(PermissionList {
-            allow: Some(vec![
-                NetworkPermission::Host(NetworkHostPermission {
-                    host: "*.example.com".to_string(),
-                }),
-                NetworkPermission::Host(NetworkHostPermission {
-                    host: "api.service.com".to_string(),
-                }),
-            ]),
-            deny: Some(vec![NetworkPermission::Host(NetworkHostPermission {
-                host: "*.malicious.com".to_string(),
-            })]),
-        });
-
-        // Test environment with valid keys (no wildcards allowed)
-        permissions.environment = Some(EnvironmentPermissions {
-            allow: Some(vec![
-                EnvironmentPermission {
-                    key: "PATH".to_string(),
-                },
-                EnvironmentPermission {
-                    key: "HOME".to_string(),
-                },
-                EnvironmentPermission {
-                    key: "MY_DEBUG_VAR".to_string(),
-                },
-            ]),
-        });
+        let permissions = Permissions {
+            storage: Some(PermissionList {
+                allow: Some(vec![
+                    StoragePermission {
+                        uri: "fs://work/agent/**".to_string(),
+                        access: vec![AccessType::Read, AccessType::Write],
+                    },
+                    StoragePermission {
+                        uri: "fs://work/*/temp".to_string(),
+                        access: vec![AccessType::Read],
+                    },
+                ]),
+                deny: Some(vec![StoragePermission {
+                    uri: "fs://work/agent/secret/*".to_string(),
+                    access: vec![AccessType::Write],
+                }]),
+            }),
+            network: Some(PermissionList {
+                allow: Some(vec![
+                    NetworkPermission::Host(NetworkHostPermission {
+                        host: "*.example.com".to_string(),
+                    }),
+                    NetworkPermission::Host(NetworkHostPermission {
+                        host: "api.service.com".to_string(),
+                    }),
+                ]),
+                deny: Some(vec![NetworkPermission::Host(NetworkHostPermission {
+                    host: "*.malicious.com".to_string(),
+                })]),
+            }),
+            // Test environment with valid keys (no wildcards allowed)
+            environment: Some(EnvironmentPermissions {
+                allow: Some(vec![
+                    EnvironmentPermission {
+                        key: "PATH".to_string(),
+                    },
+                    EnvironmentPermission {
+                        key: "HOME".to_string(),
+                    },
+                    EnvironmentPermission {
+                        key: "MY_DEBUG_VAR".to_string(),
+                    },
+                ]),
+            }),
+            ..Default::default()
+        };
 
         assert!(permissions.validate().is_ok());
     }
 
     #[test]
     fn test_invalid_wildcard_combinations() {
-        let mut permissions = Permissions::default();
+        let mut permissions = Permissions {
+            storage: Some(PermissionList {
+                allow: Some(vec![StoragePermission {
+                    uri: "fs://work/agent/**file".to_string(),
+                    access: vec![AccessType::Read],
+                }]),
+                deny: None,
+            }),
+            ..Default::default()
+        };
 
-        permissions.storage = Some(PermissionList {
-            allow: Some(vec![StoragePermission {
-                uri: "fs://work/agent/**file".to_string(),
-                access: vec![AccessType::Read],
-            }]),
-            deny: None,
-        });
         assert!(permissions.validate().is_err());
 
         permissions = Permissions::default();


### PR DESCRIPTION
This uses a shared cache key that should only change when deps change or the rust version changes. This means the cache should be reused across various builds as well

Fixes #95