### PR TITLE
Add a troubleshooting step to winget.md

### DIFF
--- a/docs/winget.md
+++ b/docs/winget.md
@@ -14,6 +14,13 @@ curl -o Microsoft.Wassette.yaml https://raw.githubusercontent.com/microsoft/wass
 winget install --manifest Microsoft.Wassette.yaml
 ```
 
+If the installation fails, it is probably because the local installation feature is not enabled.
+You can activate it with the following command in an administrator shell:
+
+```powershell
+winget settings --enable LocalManifestFiles
+```
+
 ## Verification
 
 After installation, verify that Wassette is available:


### PR DESCRIPTION
Hi,
It's probably a temporary step until the package is available without local install.

The local installation feature needs to be activated by an administrator:

https://learn.microsoft.com/en-us/windows/package-manager/winget/install#local-install

