### PR TITLE
feat: Add LTO to release build

### DIFF
--- a/.wakatime-project
+++ b/.wakatime-project
@@ -1,0 +1,1 @@
+Late Wind 51

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,3 +89,7 @@ bytes = "1"
 tokio-rustls = "0.26"
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 rcgen = "0.14"
+
+[profile.release]
+codegen-units = 1
+lto = true


### PR DESCRIPTION
Gives a good 27% size improvement, and hopefully some speed up as well (no benchmarks to test it).

```
╰─➤ ls -la bin/wassette (before)
-rwxr-xr-x@ 1 berkus  staff  36511536 Aug  7 18:18 bin/wassette*

╰─➤ ls -la bin/wassette (after)
-rwxr-xr-x@ 1 berkus  staff  26491360 Aug  7 18:12 bin/wassette*
```
