### PR TITLE
refactor: consolidate transport flags

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -131,9 +131,7 @@ mod tests {
     fn create_test_cli_config() -> crate::Serve {
         crate::Serve {
             plugin_dir: Some(PathBuf::from("/test/plugin/dir")),
-            stdio: true,
-            sse: false,
-            streamable_http: false,
+            transport: Default::default(),
             env_vars: vec![],
             env_file: None,
         }
@@ -142,9 +140,7 @@ mod tests {
     fn empty_test_cli_config() -> crate::Serve {
         crate::Serve {
             plugin_dir: None,
-            stdio: false,
-            sse: false,
-            streamable_http: false,
+            transport: Default::default(),
             env_vars: vec![],
             env_file: None,
         }


### PR DESCRIPTION
This PR refactors the transport flag handling to leverage clap's built-in argument group validation instead of manual checking. I would have preferred to use a enum all the way through but this feature has yet to land in clap: https://github.com/clap-rs/clap/issues/2621

It also adds tests to ensure mixing transports errors.

