### PR TITLE
Fix duplicate tool registration and normalize tool outputs

### DIFF
--- a/crates/mcp-server/src/components.rs
+++ b/crates/mcp-server/src/components.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use futures::stream::{self, StreamExt};
 use rmcp::model::{CallToolRequestParam, CallToolResult, Content, Tool};
 use rmcp::{Peer, RoleServer};
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use tracing::{debug, error, info, instrument};
 use wassette::LifecycleManager;
 
@@ -124,19 +124,32 @@ pub(crate) async fn handle_component_call(
         Ok(result_str) => {
             debug!("Component call successful");
 
-            if tool_schema
+            if let Some(raw_schema) = tool_schema
                 .as_ref()
                 .and_then(|schema| schema.get("outputSchema"))
-                .is_some()
             {
-                let structured_value = parse_structured_result(&result_str);
-                let contents = vec![Content::text(result_str)];
+                if let Some(normalized_schema) = normalize_output_schema(raw_schema) {
+                    let structured_value = parse_structured_result(&result_str);
+                    let structured_value = align_structured_result_with_schema(
+                        Some(&normalized_schema),
+                        structured_value,
+                    );
+                    let contents = vec![Content::text(result_str)];
 
-                Ok(CallToolResult {
-                    content: Some(contents),
-                    structured_content: Some(structured_value),
-                    is_error: Some(false),
-                })
+                    Ok(CallToolResult {
+                        content: Some(contents),
+                        structured_content: Some(structured_value),
+                        is_error: Some(false),
+                    })
+                } else {
+                    let contents = vec![Content::text(result_str)];
+
+                    Ok(CallToolResult {
+                        content: Some(contents),
+                        structured_content: None,
+                        is_error: Some(false),
+                    })
+                }
             } else {
                 let contents = vec![Content::text(result_str)];
 
@@ -156,6 +169,69 @@ pub(crate) async fn handle_component_call(
 
 fn parse_structured_result(result: &str) -> Value {
     serde_json::from_str(result).unwrap_or_else(|_| Value::String(result.to_string()))
+}
+
+fn align_structured_result_with_schema(
+    output_schema: Option<&Value>,
+    structured_value: Value,
+) -> Value {
+    if let Some(schema) = output_schema {
+        if schema.get("type").and_then(|v| v.as_str()) == Some("object") {
+            if let Some(properties) = schema.get("properties").and_then(|v| v.as_object()) {
+                if properties.contains_key("result") {
+                    return match structured_value {
+                        Value::Object(obj) => {
+                            if obj.contains_key("result") {
+                                Value::Object(obj)
+                            } else {
+                                let mut wrapper = Map::new();
+                                wrapper.insert("result".to_string(), Value::Object(obj));
+                                Value::Object(wrapper)
+                            }
+                        }
+                        other => {
+                            let mut wrapper = Map::new();
+                            wrapper.insert("result".to_string(), other);
+                            Value::Object(wrapper)
+                        }
+                    };
+                }
+            }
+        }
+    }
+
+    structured_value
+}
+
+fn normalize_output_schema(schema: &Value) -> Option<Value> {
+    if schema.is_null() {
+        return None;
+    }
+
+    match schema {
+        Value::Object(map) => {
+            if map.get("type").and_then(|v| v.as_str()) == Some("object") {
+                Some(Value::Object(map.clone()))
+            } else {
+                Some(wrap_schema_in_result(schema.clone()))
+            }
+        }
+        _ => Some(wrap_schema_in_result(schema.clone())),
+    }
+}
+
+fn wrap_schema_in_result(schema: Value) -> Value {
+    let mut props = Map::new();
+    props.insert("result".to_string(), schema);
+
+    let mut wrapped = Map::new();
+    wrapped.insert("type".to_string(), Value::String("object".to_string()));
+    wrapped.insert("properties".to_string(), Value::Object(props));
+    wrapped.insert(
+        "required".to_string(),
+        Value::Array(vec![Value::String("result".to_string())]),
+    );
+    Value::Object(wrapped)
 }
 
 #[instrument(skip(lifecycle_manager))]
@@ -362,38 +438,13 @@ pub(crate) fn parse_tool_schema(tool_json: &Value) -> Option<Tool> {
     // MCP Inspector requires outputSchema.type to be "object" if provided.
     // To ensure compatibility, wrap any non-object output schema into an
     // object schema under a "result" property.
-    let output_schema = tool_json.get("outputSchema");
-
-    let output_schema_arc = if let Some(schema) = output_schema {
-        if schema.is_null() {
-            None
-        } else {
-            match schema {
-                // If it's an object and already declares type: object, keep as is
-                Value::Object(map)
-                    if map.get("type").and_then(|v| v.as_str()) == Some("object") =>
-                {
-                    Some(Arc::new(map.clone()))
-                }
-                // Otherwise, wrap the original schema inside an object
-                _ => {
-                    let mut props = serde_json::Map::new();
-                    props.insert("result".to_string(), schema.clone());
-
-                    let mut wrapped = serde_json::Map::new();
-                    wrapped.insert("type".to_string(), Value::String("object".to_string()));
-                    wrapped.insert("properties".to_string(), Value::Object(props));
-                    wrapped.insert(
-                        "required".to_string(),
-                        Value::Array(vec![Value::String("result".to_string())]),
-                    );
-                    Some(Arc::new(wrapped))
-                }
-            }
-        }
-    } else {
-        None
-    };
+    let output_schema_arc = tool_json
+        .get("outputSchema")
+        .and_then(|schema| normalize_output_schema(schema))
+        .and_then(|normalized| match normalized {
+            Value::Object(map) => Some(Arc::new(map)),
+            _ => None,
+        });
 
     debug!(
         tool_name = %name,
@@ -495,6 +546,55 @@ mod tests {
     fn test_parse_structured_result_with_text() {
         let parsed = parse_structured_result("plain text");
         assert_eq!(parsed, json!("plain text"));
+    }
+
+    #[test]
+    fn test_normalize_output_schema_wraps_scalar() {
+        let inner = json!({"type": "string"});
+        let normalized = normalize_output_schema(&inner).unwrap();
+        assert_eq!(
+            normalized,
+            json!({
+                "type": "object",
+                "properties": {"result": inner},
+                "required": ["result"]
+            })
+        );
+    }
+
+    #[test]
+    fn test_normalize_output_schema_handles_null() {
+        assert!(normalize_output_schema(&Value::Null).is_none());
+    }
+
+    #[test]
+    fn test_align_structured_result_with_schema_wraps_missing_result() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "result": {"type": "string"}
+            },
+            "required": ["result"]
+        });
+
+        let aligned =
+            align_structured_result_with_schema(Some(&schema), Value::String("hello".into()));
+        assert_eq!(aligned, json!({"result": "hello"}));
+    }
+
+    #[test]
+    fn test_align_structured_result_with_schema_respects_existing_result() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "result": {"type": "string"}
+            },
+            "required": ["result"]
+        });
+
+        let original = json!({"result": {"ok": "16"}});
+        let aligned = align_structured_result_with_schema(Some(&schema), original.clone());
+        assert_eq!(aligned, original);
     }
 
     #[test]

--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -1434,6 +1434,15 @@ impl LifecycleManager {
                 if Self::validate_stamp(&entry_path, &metadata.validation_stamp).await {
                     // Register tools from cached metadata
                     let mut registry_write = self.registry.write().await;
+
+                    // If the component is already registered (e.g. from an eager load), skip to
+                    // avoid duplicate tool registrations that would break lookups. This can
+                    // happen when the loaded constructors are combined with the background loader.
+                    if registry_write.component_map.contains_key(component_id) {
+                        debug!(component_id = %component_id, "Skipping cached metadata; component already registered");
+                        continue;
+                    }
+
                     let tool_metadata: Vec<ToolMetadata> = metadata
                         .function_identifiers
                         .into_iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -496,7 +496,9 @@ async fn main() -> Result<()> {
                 let config =
                     config::Config::from_serve(cfg).context("Failed to load configuration")?;
 
-                let lifecycle_manager = LifecycleManager::new_with_config(
+                // Build the lifecycle manager without eagerly loading components so the
+                // background loader is the single source of tool registration.
+                let lifecycle_manager = LifecycleManager::new_unloaded_with_config(
                     &config.plugin_dir,
                     config.environment_vars,
                     &config.secrets_dir,


### PR DESCRIPTION
- switch the serve startup path to build an unloaded lifecycle manager so the background loader is the sole source of tool registration
- guard metadata warm-up against already-registered components to stop duplicate tool entries when eager and background loading both run
- normalize tool output schemas and wrap structured results to satisfy MCP inspector validation (e.g. eval now returns {"result": {...}})

Signed-off-by: Jiaxiao Zhou <duibao55328@gmail.com>
