### PR TITLE
chore: update winget and homebrew for v0.3.0

### DIFF
--- a/Formula/wassette.rb
+++ b/Formula/wassette.rb
@@ -3,25 +3,25 @@ class Wassette < Formula
   homepage "https://github.com/microsoft/wassette"
   # Change this to install a different version of wassette.
   # The release tag in GitHub must exist with a 'v' prefix (e.g., v0.1.0).
-  version "0.2.0"
+  version "0.3.0"
 
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_darwin_amd64.tar.gz"
-      sha256 "29484bc445907ced569b22adf1c2ec8a244c55818a3a7e26ed49af7ba1203be2"
+      sha256 "2800d0ea1f722fb6814caed07f7b93ab1fa637f75b3a096d8b482158c8c2eb98"
     else
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_darwin_arm64.tar.gz"
-      sha256 "9ce7611910b430f5f4a631d420743ecc831883178e72309ddc21269efcf1a2c6"
+      sha256 "394ede6bd2ad8420e59d4cd88e6a6c0299e6b7997b044599282f0d6941c5d575"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_linux_amd64.tar.gz"
-      sha256 "ee75388f649244a6fb1d15b864a5551e761213315d1bd4cf710b29b17e4f5435"
+      sha256 "7510424ce5ef7db02ae8e02d8dbf49ce1a723cec61451201d3107a405f56d6c9"
     else
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_linux_arm64.tar.gz"
-      sha256 "f0461a51b13b24acda002b42df08846d6d001d021d3fd91ea316521d4f417ecf"
+      sha256 "fa92161cf0bf1644f368ab4f87bdcd4483079d679ed7baeebfbbeb5a0e43df9a"
     end
   end
 

--- a/winget/Microsoft.Wassette.yaml
+++ b/winget/Microsoft.Wassette.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.6.0.schema.json
 
 PackageIdentifier: Microsoft.Wassette
-PackageVersion: 0.2.0
+PackageVersion: 0.3.0
 PackageLocale: en-US
 Publisher: Microsoft Corporation
 PublisherUrl: https://github.com/microsoft/wassette
@@ -29,20 +29,20 @@ Tags:
 - sandbox
 - runtime
 - component
-ReleaseDate: 2025-08-05
+ReleaseDate: 2025-10-03
 Installers:
 - Architecture: x64
   InstallerType: zip
-  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.2.0/wassette_0.2.0_windows_amd64.zip
-  InstallerSha256: 44347c041662eef2ecbcafeb23ea0e7ac9f10cccc2d8094d0db346c79198a334
+  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.3.0/wassette_0.3.0_windows_amd64.zip
+  InstallerSha256: fa92161cf0bf1644f368ab4f87bdcd4483079d679ed7baeebfbbeb5a0e43df9a 
   NestedInstallerType: portable
   NestedInstallerFiles:
   - RelativeFilePath: wassette.exe
     PortableCommandAlias: wassette
 - Architecture: arm64
   InstallerType: zip
-  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.2.0/wassette_0.2.0_windows_arm64.zip
-  InstallerSha256: 6383a039338ed5b59d2a969ba0abdc6d8750a584749317a7f70d039575b4a2fd
+  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.3.0/wassette_0.3.0_windows_arm64.zip
+  InstallerSha256: 8e8be37fa39abf2a90b80debda24013dff2e443a2b90b8db26f530e369468b6d
   NestedInstallerType: portable
   NestedInstallerFiles:
   - RelativeFilePath: wassette.exe


### PR DESCRIPTION
This pull request updates the Wassette package to version 0.3.0 across both Homebrew and Winget manifests. The changes ensure that installation scripts and metadata reference the latest release and its corresponding checksums, improving reliability and consistency for users installing or upgrading Wassette.

**Version and release updates:**

* Updated the Wassette version from `0.2.0` to `0.3.0` in both `Formula/wassette.rb` and `winget/Microsoft.Wassette.yaml`, ensuring all installation sources point to the latest release. [[1]](diffhunk://#diff-5adddb6167d1de4d14c4c877921a5ffd657b3933be0c5205f357de162bc392d0L6-R24) [[2]](diffhunk://#diff-4126d6a0e77604fd864c1690ea2f8ba32c643b6a9e7946010738d6f9479466bbL4-R4)
* Changed the `ReleaseDate` in the Winget manifest to `2025-10-03` to reflect the new release.

**Installer and checksum updates:**

* Updated all installer URLs and SHA256 checksums in both Homebrew and Winget manifests to match the new Wassette 0.3.0 release files for macOS, Linux, and Windows (x64 and arm64 architectures). This ensures integrity and compatibility for all supported platforms. [[1]](diffhunk://#diff-5adddb6167d1de4d14c4c877921a5ffd657b3933be0c5205f357de162bc392d0L6-R24) [[2]](diffhunk://#diff-4126d6a0e77604fd864c1690ea2f8ba32c643b6a9e7946010738d6f9479466bbL32-R45)