### PR TITLE
fix: update samples latest after release is published

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -9,6 +9,8 @@ on:
     branches: [ "main" ]
     paths:
       - 'examples/**'
+  release:
+    types: [publish]
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
This pull request updates the workflow triggers in `.github/workflows/examples.yml` to ensure the workflow also runs on `release` events of type `publish`, in addition to the existing triggers.