### PR TITLE
chore(release): bump version to 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "wassette-mcp-server"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wassette-mcp-server"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license.workspace = true
 


### PR DESCRIPTION
This pull request prepares for the 0.3.3 release by updating the version in `Cargo.toml` and `Cargo.lock`.

## Changes
- Updated version in `Cargo.toml` to `0.3.3`
- Updated `Cargo.lock` to reflect the version change

## Next Steps
1. Review and merge this PR
2. After merge, create and push a new tag: `git tag -s v0.3.3 -m "Release v0.3.3"`
3. Push the tag: `git push origin v0.3.3`
4. The release workflow will automatically trigger and create the GitHub release
5. The update-package-manifests workflow will automatically create a PR to update Homebrew and WinGet manifests