### PR TITLE
chore(release): bump version to 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4940,7 +4940,7 @@ dependencies = [
 
 [[package]]
 name = "wassette-mcp-server"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wassette-mcp-server"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license.workspace = true
 


### PR DESCRIPTION
This pull request prepares for the 0.3.4 release by updating the version in `Cargo.toml` and `Cargo.lock`.

## Changes
- Updated version in `Cargo.toml` to `0.3.4`
- Updated `Cargo.lock` to reflect the version change

## Next Steps
1. Review and merge this PR to main
2. After merge, the release branch `release/v0.3.4` will be preserved for the release process
3. Create and push a new tag on main: `git tag -s v0.3.4 -m "Release v0.3.4"`
4. Push the tag: `git push origin v0.3.4`
5. The release workflow will automatically trigger and create the GitHub release
6. The release workflow will update CHANGELOG.md and create a PR to merge changes back to main
7. The update-package-manifests workflow will automatically create a PR to update Homebrew and WinGet manifests

**Note:** The release branch will be kept for the release process and will be merged back to main after the release is complete.