### PR TITLE
feat(component2json): add integer-based resource handle serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4491,15 +4491,26 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.242.0"
+version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3c6e611f4cd748d85c767815823b777dc56afca793fcda27beae4e85028849"
+checksum = "b722dcf61e0ea47440b53ff83ccb5df8efec57a69d150e4f24882e4eba7e24a4"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
  "indexmap 2.12.0",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.242.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3c6e611f4cd748d85c767815823b777dc56afca793fcda27beae4e85028849"
+dependencies = [
+ "bitflags",
+ "indexmap 2.12.0",
+ "semver",
 ]
 
 [[package]]

--- a/crates/component2json/README.md
+++ b/crates/component2json/README.md
@@ -6,7 +6,7 @@ A Rust library for converting WebAssembly Components to JSON Schema and handling
 
 ```rust
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-use component2json::{component_exports_to_json_schema, json_to_vals, vals_to_json, create_placeholder_results};
+use component2json::{component_exports_to_json_schema, json_to_vals, vals_to_json, create_placeholder_results, ResourceHandleTable};
 use wasmtime::component::{Component, Type, Val};
 use wasmtime::Engine;
 
@@ -29,18 +29,21 @@ let func_param_types = vec![
     ("value".to_string(), Type::U32),
 ];
 
+// Create a handle table for resource management
+let mut handles = ResourceHandleTable::new();
+
 // Convert a JSON object to WIT values according to the function's parameter types
 let json_args = serde_json::json!({
     "name": "example",
     "value": 42
 });
-let wit_vals = json_to_vals(&json_args, &func_param_types)?;
+let wit_vals = json_to_vals(&json_args, &func_param_types, &mut handles)?;
 
 // Convert WIT values back to JSON
-let json_result = vals_to_json(&wit_vals);
+let json_result = vals_to_json(&wit_vals, &mut handles);
 assert_eq!(json_result, serde_json::json!({"result": {"val0": "example", "val1": 42}}));
 
-// Create placeholder results for function call results
+// Create placeholder results for function call calls
 // This is useful when you need to prepare storage for function return values
 let result_types = vec![Type::String, Type::U32];
 let placeholder_results = create_placeholder_results(&result_types);
@@ -184,9 +187,11 @@ The generated `outputSchema` for each tool mirrors this shape, ensuring downstre
 
 ##### Resources
 
+Resources are represented as integer handles that reference live resource instances in a `ResourceHandleTable`:
+
 ```json
 {
-    "type": "string",
-    "description": "RESOURCE_TYPE resource: RESOURCE_NAME"
+    "type": "integer",
+    "description": "Handle to owned/borrowed resource: RESOURCE_NAME"
 }
 ```


### PR DESCRIPTION
## Summary

Implements #601 - WIT resource type support for MCP tool calls.

- Add `ResourceHandleTable` for mapping integer handles to `ResourceAny` values
- Update `val_to_json`/`json_to_val` to accept handle table parameter
- Resources serialize to integers (not debug strings) and can be passed back to components via their integer handles
- Update schema generation to use `"type": "integer"` for resources
- Handle tables persist per-component in `LifecycleManager`, enabling multi-call workflows (open → read → close)

This enables `wasi:filesystem` workflows where file descriptors need to persist across multiple tool calls.

## Test plan

- [x] All existing unit tests updated and passing (46 tests in component2json, 92 in wassette)
- [x] Doctest updated and passing
- [x] README documentation updated

## Disclosure

This PR was developed with assistance from Claude (Anthropic's AI assistant).