### PR TITLE
chore(release): bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5126,7 +5126,7 @@ dependencies = [
 
 [[package]]
 name = "wassette-mcp-server"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wassette-mcp-server"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 license.workspace = true
 


### PR DESCRIPTION
This pull request prepares for the 0.4.0 release by updating the version in `Cargo.toml` and `Cargo.lock`.

## Changes
- Updated version in `Cargo.toml` to `0.4.0`
- Updated `Cargo.lock` to reflect the version change

## Next Steps
1. Review and merge this PR to main
2. After merge, the `auto-tag-release` workflow will automatically create and push tag `v0.4.0`
3. The release workflow will automatically trigger and create the GitHub release
4. The release workflow will update CHANGELOG.md and create a PR to merge changes back to main
5. The update-package-manifests workflow will automatically create a PR to update Homebrew and WinGet manifests

**Note:** The release branch will be kept for the release process and will be merged back to main after the release is complete.