### PR TITLE
chore: update winget and homebrew for v0.4.0

### DIFF
--- a/Formula/wassette.rb
+++ b/Formula/wassette.rb
@@ -3,25 +3,25 @@ class Wassette < Formula
   homepage "https://github.com/microsoft/wassette"
   # Change this to install a different version of wassette.
   # The release tag in GitHub must exist with a 'v' prefix (e.g., v0.1.0).
-  version "0.3.0"
+  version "0.4.0"
 
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_darwin_amd64.tar.gz"
-      sha256 "2800d0ea1f722fb6814caed07f7b93ab1fa637f75b3a096d8b482158c8c2eb98"
+      sha256 "238495eb97335180a91cb489159f5c6df22d5096bd4353ebe767d1e64bd39e1a"
     else
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_darwin_arm64.tar.gz"
-      sha256 "394ede6bd2ad8420e59d4cd88e6a6c0299e6b7997b044599282f0d6941c5d575"
+      sha256 "15be357089ee7a01d3af17000561902cf7825cdfa93a8437f077ddb2cc77f39d"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_linux_amd64.tar.gz"
-      sha256 "7510424ce5ef7db02ae8e02d8dbf49ce1a723cec61451201d3107a405f56d6c9"
+      sha256 "0f96dd67bc4b4f8a83a2b4a65181b6bcf0f08e9de9270e9ee97297be7bfec368"
     else
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_linux_arm64.tar.gz"
-      sha256 "fa92161cf0bf1644f368ab4f87bdcd4483079d679ed7baeebfbbeb5a0e43df9a"
+      sha256 "4e6068d8b7386e3ad9031eb9d2f1c4e4d7d6d90b2269a425e13c26364e5e6683"
     end
   end
 

--- a/winget/Microsoft.Wassette.yaml
+++ b/winget/Microsoft.Wassette.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.6.0.schema.json
 
 PackageIdentifier: Microsoft.Wassette
-PackageVersion: 0.3.0
+PackageVersion: 0.4.0
 PackageLocale: en-US
 Publisher: Microsoft Corporation
 PublisherUrl: https://github.com/microsoft/wassette
@@ -29,20 +29,20 @@ Tags:
 - sandbox
 - runtime
 - component
-ReleaseDate: 2025-10-03
+ReleaseDate: 2026-02-04
 Installers:
 - Architecture: x64
   InstallerType: zip
-  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.3.0/wassette_0.3.0_windows_amd64.zip
-  InstallerSha256: fa92161cf0bf1644f368ab4f87bdcd4483079d679ed7baeebfbbeb5a0e43df9a 
+  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.4.0/wassette_0.4.0_windows_amd64.zip
+  InstallerSha256: f6a5f18f61b313c5dd2c7fef0a2863b1df02522da3eba855ecbebe9e8e600206
   NestedInstallerType: portable
   NestedInstallerFiles:
   - RelativeFilePath: wassette.exe
     PortableCommandAlias: wassette
 - Architecture: arm64
   InstallerType: zip
-  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.3.0/wassette_0.3.0_windows_arm64.zip
-  InstallerSha256: 8e8be37fa39abf2a90b80debda24013dff2e443a2b90b8db26f530e369468b6d
+  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.4.0/wassette_0.4.0_windows_arm64.zip
+  InstallerSha256: d12e8909a0a1750d20a96390189a64b530c4250839e7978ea4ac0e33a3c84e96
   NestedInstallerType: portable
   NestedInstallerFiles:
   - RelativeFilePath: wassette.exe


### PR DESCRIPTION
This pull request updates the Wassette package to version 0.4.0 across both Homebrew and WinGet manifests. The changes ensure that installation scripts and metadata reference the latest release and its corresponding checksums.

## Version and release updates

* Updated the Wassette version to `0.4.0` in both `Formula/wassette.rb` and `winget/Microsoft.Wassette.yaml`
* Changed the `ReleaseDate` in the WinGet manifest to reflect the new release

## Installer and checksum updates

* Updated all installer URLs and SHA256 checksums in both Homebrew and WinGet manifests to match the new Wassette 0.4.0 release files for all supported platforms

### Checksums

- **macOS AMD64**: `238495eb97335180a91cb489159f5c6df22d5096bd4353ebe767d1e64bd39e1a`
- **macOS ARM64**: `15be357089ee7a01d3af17000561902cf7825cdfa93a8437f077ddb2cc77f39d`
- **Linux AMD64**: `0f96dd67bc4b4f8a83a2b4a65181b6bcf0f08e9de9270e9ee97297be7bfec368`
- **Linux ARM64**: `4e6068d8b7386e3ad9031eb9d2f1c4e4d7d6d90b2269a425e13c26364e5e6683`
- **Windows AMD64**: `f6a5f18f61b313c5dd2c7fef0a2863b1df02522da3eba855ecbebe9e8e600206`
- **Windows ARM64**: `d12e8909a0a1750d20a96390189a64b530c4250839e7978ea4ac0e33a3c84e96`

---

*This PR was manually created because the automated update-package-manifests workflow failed due to token issues.*