### PR TITLE
Repair dependency-update CI and migrate to secure HTTP transport

### DIFF
--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -65,19 +65,19 @@ grep -q "Copyright (c) Microsoft Corporation" your_file.rs
 ## Debugging
 
 
-You can use commands in the Justfile to start the wassette mcp server (`just run`) and to run the tests (`just test`). `just run` will start the server that listens to "127.0.0.1:9001/sse". 
+You can use commands in the Justfile to start the wassette mcp server (`just run`) and to run the tests (`just test`). `just run` will start the server that listens at `127.0.0.1:9001/mcp`.
 
 Then you can use `npx @modelcontextprotocol/inspector` to connect to the server and inspect the state of the MCP server.
 
 The following is a list of sample CLI commands you can use to interact with the MCP server:
 
 ```bash
-# Connect to a remote MCP server (default is SSE transport)
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse
+# Connect to the Streamable HTTP MCP server
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http
 
 # List tools from a remote server
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/list
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/list
 
 # Call a tool on a remote server
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/call --tool-name remotetool --tool-arg param=value
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/call --tool-name remotetool --tool-arg param=value
 ```

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,9 +100,9 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
     - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
     - name: Install cargo-audit
-      run: cargo install cargo-audit
+      run: cargo install cargo-audit --locked
     - name: Install cargo-deny
-      run: cargo install cargo-deny
+      run: cargo install cargo-deny --locked
     - name: Run cargo audit
       run: |
         # Run cargo audit - fail only on actual vulnerabilities, not warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,7 +108,7 @@ jobs:
         # Run cargo audit - fail only on actual vulnerabilities, not warnings
         cargo audit
     - name: Run cargo deny check
-      run: cargo deny check --config .config/deny.toml advisories licenses bans sources
+      run:       cargo deny --config .config/deny.toml check advisories licenses bans sources
 
   coverage:
     name: test coverage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,7 +108,7 @@ jobs:
         # Run cargo audit - fail only on actual vulnerabilities, not warnings
         cargo audit
     - name: Run cargo deny check
-      run:       cargo deny --config .config/deny.toml check advisories licenses bans sources
+      run: cargo deny --config .config/deny.toml check advisories licenses bans sources
 
   coverage:
     name: test coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ This workflow applies to all changes: bug fixes, new features, refactoring, docu
 Start the Wassette MCP server for development and debugging:
 
 ```bash
-# Start server with SSE transport (listens on 127.0.0.1:9001/sse)
+# Start server with Streamable HTTP (listens on 127.0.0.1:9001/mcp)
 just run
 
 # Start with custom log level
@@ -165,17 +165,17 @@ The MCP Inspector is your primary tool for testing and validating changes. Alway
 Connect to the running Wassette server and interact with it:
 
 ```bash
-# Connect to local Wassette server (default SSE transport)
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse
+# Connect to the local Streamable HTTP server
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http
 
 # List available tools (always run this first to see what's available)
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/list
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/list
 
 # List available resources
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method resources/list
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method resources/list
 
 # List available prompts
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method prompts/list
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method prompts/list
 ```
 
 #### Calling Tools
@@ -184,13 +184,13 @@ Test tool functionality by calling them with various arguments:
 
 ```bash
 # Call a tool with simple arguments
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/call --tool-name mytool --tool-arg param=value
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/call --tool-name mytool --tool-arg param=value
 
 # Call a tool with multiple arguments
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/call --tool-name mytool --tool-arg key1=value1 --tool-arg key2=value2
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/call --tool-name mytool --tool-arg key1=value1 --tool-arg key2=value2
 
 # Call a tool with JSON arguments (for complex parameters)
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/call --tool-name mytool --tool-arg 'options={"format": "json", "max_tokens": 100}'
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/call --tool-name mytool --tool-arg 'options={"format": "json", "max_tokens": 100}'
 ```
 
 #### Testing with Different Transports
@@ -198,12 +198,9 @@ npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method too
 Wassette supports multiple transport protocols. Test with both:
 
 ```bash
-# SSE transport (default, recommended for development)
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse
-
 # Streamable HTTP transport
 just run-streamable  # Start server with streamable HTTP transport
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001 --transport http --method tools/list
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/list
 ```
 
 #### Testing with Custom Headers
@@ -212,7 +209,7 @@ If testing authentication or custom headers:
 
 ```bash
 # Add custom headers to requests
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --transport http --method tools/list --header "X-API-Key: your-api-key"
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/list --header "X-API-Key: your-api-key"
 ```
 
 #### Testing with Configuration Files
@@ -234,10 +231,10 @@ just run-fetch-rs
 
 # Terminal 2: Test the component
 # List available tools
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/list
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/list
 
 # Call the fetch tool
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/call --tool-name fetch --tool-arg url=https://api.github.com/repos/microsoft/wassette
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/call --tool-name fetch --tool-arg url=https://api.github.com/repos/microsoft/wassette
 ```
 
 #### Example 2: Testing the Filesystem Component
@@ -248,13 +245,13 @@ just run-filesystem
 
 # Terminal 2: Test filesystem operations
 # List tools
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/list
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/list
 
 # Test reading a file
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/call --tool-name read_file --tool-arg path=/tmp/test.txt
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/call --tool-name read_file --tool-arg path=/tmp/test.txt
 
 # Test listing directory
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/call --tool-name list_directory --tool-arg path=/tmp
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/call --tool-name list_directory --tool-arg path=/tmp
 ```
 
 #### Example 3: Testing After Code Changes
@@ -270,10 +267,10 @@ just build
 just run-fetch-rs
 
 # 4. Verify tools are available
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/list
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/list
 
 # 5. Test specific functionality you changed
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/call --tool-name your-tool --tool-arg test=value
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/call --tool-name your-tool --tool-arg test=value
 
 # 6. Include output in your commit message or PR description
 ```
@@ -284,10 +281,10 @@ Always capture the inspector output to demonstrate that your changes work:
 
 ```bash
 # Save inspector output to a file
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/list > inspector-output.txt
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/list > inspector-output.txt
 
 # Or capture a full testing session
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/call --tool-name mytool --tool-arg test=value 2>&1 | tee test-results.txt
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/call --tool-name mytool --tool-arg test=value 2>&1 | tee test-results.txt
 ```
 
 Include this output in:
@@ -438,8 +435,8 @@ cargo clippy            # Run linter
 
 # Testing with Inspector (ALWAYS do this before committing)
 just run                # Terminal 1: Start server
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/list    # Terminal 2: List tools
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/call --tool-name TOOL_NAME --tool-arg key=value    # Test a tool
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/list    # Terminal 2: List tools
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/call --tool-name TOOL_NAME --tool-arg key=value    # Test a tool
 
 # Documentation
 just docs-serve         # View docs locally

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -127,7 +127,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -139,20 +139,20 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
+checksum = "b18457efd137254e016bbde5e1d88df61c4e1a5ae2223746e56123bac6af2463"
 dependencies = [
- "filetime",
  "futures-core",
  "libc",
  "portable-atomic",
  "rustc-hash",
+ "rustix 1.1.4",
  "tokio",
  "tokio-stream",
  "xattr",
@@ -177,18 +177,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -214,9 +214,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -225,14 +225,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -288,22 +289,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -331,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -380,14 +369,14 @@ dependencies = [
  "num",
  "pin-project-lite",
  "rand 0.9.5",
- "rustls 0.23.40",
+ "rustls 0.23.42",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "tokio-stream",
@@ -456,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -521,7 +510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
 dependencies = [
  "ambient-authority",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -552,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -570,15 +559,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -587,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -601,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -632,14 +621,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -663,7 +652,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -688,17 +677,11 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasmparser 0.245.1",
  "wasmtime",
  "wat",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -782,36 +765,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.10"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2be1bdbf929c2a2242cbbe15d6583c56f1cc723c6c8452d0179362de28c9d5"
+checksum = "3cd990d8a6304475bbad64534a0d418f5572f44d5f011437e6b9f1ee7d5c2570"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.10"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0336914de11298290783a95a9a7154b894da601659eb5f8f8bc62d1bea98f8"
+checksum = "ccabe4636007296721080e02d7dab46d4319638ec4e3f6f7402fcb46dc5122c6"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.10"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb972cba51a52c1b2a329fec993b911e4d1f9cfab3795811a319b6746c28e014"
+checksum = "da7ed173c870c0aea202a9830880156905a028a88df076e35ce383a8acbf90a7"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.10"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642c920666bfed9aebca39d8c6e7cb76f09314cc7a4074b1db5edcccdde771b9"
+checksum = "800cc586df98b12c502e76707c96565e40629a5322eaa15aaa34ba05f5721e31"
 dependencies = [
  "serde",
  "serde_derive",
@@ -819,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.10"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1231caaeee3d2363d9b2dba9d6c1f7ff835b8ede6612fba98120af73df44bd"
+checksum = "ae93f863f9094ae34d2567f9edb0ae2c41d35228b286598354dd78b198868ebd"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -846,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.10"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb83e89be8b413e4f7a4215a02d5c5f3e6f04b1060f5db293dd1007b2871dcf5"
+checksum = "38c505162bcf77dcb859905b3eac56a1917fc3cf326424fb06e7732031e3a8ae"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -859,24 +842,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.10"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d14f8068a98f0a85ffa63dc5fe73cb486a955adbe7311465d13cde54c656d5f"
+checksum = "e3b786958bcb79bdb5fbae095af58f0c2da7d7895c475c991f6a6bb5a9c7e6d9"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.10"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c070aee9312b9736028e99b58d45e1099683386082af38529d5e2ce8c76648f3"
+checksum = "2faf9a5009bce7f725ce2af7a08c4883ebac6af933e7e0aa7d84f976f4e6deb5"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.10"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d619bb3d14251e96dc9b6a846d6955d78048a168cc3876eb2b789b855c1c22"
+checksum = "017271194ba5e101d626560d0d6767efd341468d1ba0f4d015f19fe64020b65b"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -885,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.10"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2350fcff24d78be5e4201e1eeb4b306e474b9f21e452722b21ffc4f773e8d49a"
+checksum = "f80847f0929967f0cec82f9e0543b3901e0f0063690405891f22107b5a130fd8"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -897,15 +880,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.10"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdc2b14d7491c53c2989b967b4c07511374733abbc01a895fb01ea31e97bfc8"
+checksum = "75904abbc0e7b46d20f7a49c8042c8a4481c0db4253b99889c723c566295d506"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.10"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98dbe1326d0001a17b3b0675e3adafcfbd0e7f25f1f845a2f1bb9ce3029f359"
+checksum = "6e0135923540574362e16f01bf40000664263840991039ff3041ba717de6cf3a"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -914,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.10"
+version = "0.123.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d7af563cd300c8a1e4e64387929b40e32867112143f0a0e1ce90f977ce4a41"
+checksum = "93fb12f76c482e034f6ebefa843c914e74112f088215d8d36d33a649f9fab99b"
 
 [[package]]
 name = "crc32fast"
@@ -929,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -939,30 +922,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -984,33 +955,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,16 +962,6 @@ checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core 0.20.11",
  "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -1051,21 +985,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1078,7 +998,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1089,18 +1009,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
- "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1111,7 +1020,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1127,17 +1036,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
-]
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468",
- "zeroize",
 ]
 
 [[package]]
@@ -1160,7 +1058,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1182,7 +1079,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1192,7 +1089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1202,9 +1099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -1214,7 +1109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.2",
 ]
 
@@ -1247,7 +1142,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1274,69 +1169,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "embedded-io"
@@ -1361,18 +1197,19 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
+ "regex",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1393,7 +1230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1414,9 +1251,9 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fd-lock"
@@ -1436,25 +1273,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
 dependencies = [
  "portable-atomic",
- "rand 0.10.1",
+ "rand 0.10.2",
  "web-time",
 ]
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "figment"
@@ -1468,16 +1289,6 @@ dependencies = [
  "toml",
  "uncased",
  "version_check",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
-dependencies = [
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -1503,21 +1314,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1547,9 +1343,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1562,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1572,15 +1368,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1589,38 +1385,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1663,7 +1459,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1686,37 +1481,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "getset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1743,21 +1535,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1827,24 +1608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,9 +1637,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1918,9 +1681,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1940,9 +1703,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-named-pipe"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+checksum = "fab3637d6b04a8037af8a266fdf6cf92ea957e8c53981a2bf6136572531025bf"
 dependencies = [
  "hex",
  "hyper",
@@ -1950,7 +1713,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
- "winapi",
 ]
 
 [[package]]
@@ -1962,7 +1724,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.40",
+ "rustls 0.23.42",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -1978,22 +1740,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2280,7 +2026,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -2295,7 +2041,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2314,28 +2060,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2347,17 +2092,10 @@ checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64",
- "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
  "js-sys",
- "p256",
- "p384",
- "rand 0.8.6",
- "rsa",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "signature",
  "zeroize",
 ]
@@ -2382,15 +2120,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "leb128fmt"
@@ -2400,9 +2135,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libgit2-sys"
@@ -2424,9 +2159,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -2472,9 +2207,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2529,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memfd"
@@ -2556,30 +2291,13 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -2598,7 +2316,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2617,28 +2335,12 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
 ]
 
 [[package]]
@@ -2667,11 +2369,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2694,7 +2395,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2721,32 +2421,6 @@ dependencies = [
 
 [[package]]
 name = "oci-client"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7f8deaffcd3b0e3baf93dddcab3d18b91d46dc37d38a8b170089b234de5bb3"
-dependencies = [
- "bytes",
- "chrono",
- "futures-util",
- "http",
- "http-auth",
- "jsonwebtoken",
- "lazy_static",
- "oci-spec",
- "olpc-cjson",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "unicase",
-]
-
-[[package]]
-name = "oci-client"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5261a7fb43d9c53b8e63e6d5e86860719dad253d015d022066c72d585125aed8"
@@ -2766,7 +2440,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "unicase",
@@ -2786,24 +2460,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "oci-wasm"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841cceed413ad8a4c8b4a833ccfa333eebe55dfb12af7c3899687258934ca2a4"
-dependencies = [
- "anyhow",
- "chrono",
- "oci-client 0.16.1",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tokio",
- "wit-component 0.244.0",
- "wit-parser 0.244.0",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2814,12 +2471,12 @@ checksum = "87689298bd74f0f2675fcac99956a34c31098ca3bdced3d7635e71dc03c5ca21"
 dependencies = [
  "anyhow",
  "chrono",
- "oci-client 0.17.0",
+ "oci-client",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "tokio",
- "wit-component 0.253.0",
+ "wit-component",
  "wit-parser 0.253.0",
 ]
 
@@ -2856,71 +2513,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
 
 [[package]]
 name = "parking_lot"
@@ -2967,14 +2563,14 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pear"
@@ -2996,7 +2592,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3007,15 +2603,6 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -3041,7 +2628,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3049,27 +2636,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
 
 [[package]]
 name = "pkg-config"
@@ -3089,9 +2655,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "postcard"
@@ -3130,51 +2696,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3187,7 +2712,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -3213,9 +2738,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3223,31 +2748,31 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329f575a931601f71fbcb3b31d32d16273da5ba7f532fc10be2e432e710b02de"
+checksum = "558181096e0df4984f45cfc3a7087052df4a61c36089b135a08ceca9cbd352fb"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -3257,13 +2782,13 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bccae89ed67a40989e780105fab43e6c71a077b9fc8ae4c805ff5f73d2a79c8"
+checksum = "b5d52e2f14e168d75cdabe9bd5fb1ff18a1b119dc6699684aee895dbc3524da9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3274,9 +2799,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3284,9 +2809,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.40",
+ "rustls 0.23.42",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -3294,21 +2819,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.5",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls 0.23.40",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3316,23 +2842,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3351,9 +2877,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3372,12 +2898,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3424,6 +2950,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -3490,22 +3025,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -3524,9 +3059,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3536,9 +3071,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3547,9 +3082,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -3568,16 +3103,14 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.40",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -3585,7 +3118,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
@@ -3596,16 +3128,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -3624,12 +3146,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.9.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa07b85b779d1e1df52dd79f6c6bffbe005b191f07290136cc42a142da3409a"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
- "axum",
  "base64",
  "bytes",
  "chrono",
@@ -3637,15 +3158,15 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "paste",
+ "pastey",
  "pin-project-lite",
- "rand 0.9.5",
+ "rand 0.10.2",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3656,48 +3177,28 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.9.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6fa09933cac0d0204c8a5d647f558425538ed6a0134b1ebb1ae4dc00c96db3"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3740,7 +3241,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3769,9 +3270,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3785,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3797,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3816,14 +3317,14 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.40",
+ "rustls 0.23.42",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3857,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -3932,7 +3433,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3940,20 +3441,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "security-framework"
@@ -4026,7 +3513,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4055,13 +3542,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -4114,7 +3601,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4183,15 +3670,14 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -4211,44 +3697,28 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
 dependencies = [
  "bytes",
  "futures-util",
@@ -4278,7 +3748,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4289,7 +3759,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4307,7 +3777,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4318,9 +3788,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4355,7 +3825,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4417,10 +3887,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4451,7 +3921,7 @@ checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4460,7 +3930,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
 dependencies = [
- "syn 2.0.117",
+ "syn 2.0.119",
  "test-log-core",
 ]
 
@@ -4488,7 +3958,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4506,11 +3976,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -4521,37 +3991,36 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -4561,15 +4030,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4587,9 +4056,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4619,23 +4088,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4655,7 +4114,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.40",
+ "rustls 0.23.42",
  "tokio",
 ]
 
@@ -4683,13 +4142,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4844,7 +4304,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4904,7 +4364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4994,7 +4454,7 @@ dependencies = [
  "base64",
  "log",
  "percent-encoding",
- "rustls 0.23.40",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
@@ -5045,11 +4505,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -5108,27 +4568,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5139,9 +4590,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5149,9 +4600,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5159,22 +4610,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -5187,16 +4638,6 @@ checksum = "724fccfd4f3c24b7e589d333fc0429c68042897a7e8a5f8694f31792471841e7"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.236.1",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -5217,18 +4658,6 @@ checksum = "09480d646178e5fdd12bb06e812d0af9a3a191dbc9cd697fdc86687beade7393"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.254.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -5267,18 +4696,6 @@ dependencies = [
  "indexmap 2.14.0",
  "semver",
  "serde",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -5330,9 +4747,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507d213104e83a7519d91af444a8b19c04281f2eef162d448ee7a894ac1c827d"
+checksum = "4b4442dc12aa2473def8334f0e0f2b489be52c52507c938bbdc8be69ded4ded6"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -5385,9 +4802,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9784b325c3b85562ac6d7f81c8348c42af1f137d98dd4fc6631860e4e68bb655"
+checksum = "5d881c3d6205898a226cc487b117f23b9ed1c7da39952d65bd5eeb6745b3789c"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -5412,18 +4829,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcaa9336cd5ba934ba734dfdfe35f5245c3c74b4e34f9af9e114fad892d81b3d"
+checksum = "5ab1876bcfa51d6a05dea1c13933f53cbc1e316c783fddebc859f56a736eae07"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e297746bc001fd919f8f9bb3d28ed1a01fb1ff10a5ccd9720e649b5807bf2b68"
+checksum = "2195a1521a5214a71b67ca2ba2d9317ae15917288ea9d8e5836142b921c9d155"
 dependencies = [
  "anyhow",
  "base64",
@@ -5441,14 +4858,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91aba228ec4f646cb9514be55538c842822cb96f2c306f75d664eea6b6f2e9eb"
+checksum = "8ae1407944a0b13a8a77930b5b951aa7134beccecad7efac1ef9f03adb7d1a0f"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
  "wit-parser 0.236.1",
@@ -5456,15 +4873,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f4a2387b0aea544aa2317e295583be54fed852e0d1a31c0070984bfd6a507"
+checksum = "646a53678ce6aaf6f097e18ca51f650f2841aea6d2bcd7b61931397b8b8f30db"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d938ae501275f44e7e5532ae4bb720542b429357014d33842e128c46fb9b54"
+checksum = "ab3495aa8300e4ca6b53f81a53ce5eff6621fd5ff8378ef9ae552d1479d57371"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5480,7 +4897,7 @@ dependencies = [
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-math",
@@ -5489,9 +4906,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1443b0914ff848ee7920e0f232368168e2819b739c54f3c352f0559b6164343"
+checksum = "29b5e4023a6b167da157338f5f0f505945eb45e78f1cac2d4dcce0922457d7d4"
 dependencies = [
  "anyhow",
  "cc",
@@ -5505,9 +4922,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861d6f2a1652e95ca10b02552934b3bd460d7416b285fe10d7ca8c0a2b90dc3e"
+checksum = "9da71e2d573e3cc6f753a3b7bff98f425ca060c0e8071cc55c3d867a9edf3ecc"
 dependencies = [
  "cc",
  "object",
@@ -5517,9 +4934,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1caeb3140c46319fecf09d93dc38a373eb535fd478e401a9fb2ac2da30fe5f6"
+checksum = "627d8f57909a4f9bb1dbe57a96229a54b89d5995353d0b321f3cb9a1a118977a"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5529,24 +4946,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c631615929951a4076aae64da7d6cad88668d292f19672606392c24ae9c5a00"
+checksum = "45b99315585a8a27125dd9b0150edb115d6f6ff0baae453c21d30822aab77f00"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b28104d57b5bdb5d8facb3a8418463ec6c2cb40bb4adf9833b727ebf6a254eb"
+checksum = "8eaee97281dd3fe47ec3d46c16fb9fe2dd32f37d0523c2d5c484f11b348734e4"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd89f2db7377869aeaf66b71f56def8df54b9482e4f4e5533ccec2505f5c691"
+checksum = "d0c005f82c48492b6b44fa19ee5205bd933c4f8baca41e314eca8331dd3c4fd9"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5557,20 +4974,20 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9cdb9c2e3965ee15629d067203cb800e9822664d04335dadc6fe1788d4fc335"
+checksum = "7b73639a9c0c0e33a2ef942ca99b6772b48393be92bebbd0767c607e5b0a68e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f693c8db710f20b927bcee025acd345acf599d055b63f122613d52f5553a5f"
+checksum = "392ca021d084c7426616ef77e1284315555f11bcbb34f416d74b0732db622811"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -5585,9 +5002,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c97d4e849494d290e05573298bd372e12be86b2074502dc5e02f4ef7628002"
+checksum = "7fd4703351476262d715b72431e80d10289908e3494050071d6521267f522d97"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -5598,9 +5015,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eabc75a6afeac11870ee5402268ec0f61fc394728d6dcbe5091a57dc6eb5a57"
+checksum = "21921b6e8e8ed876a288cb3b0b3aee68809fed8182ce26c9977ffc4af4cb77f6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5617,7 +5034,7 @@ dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
  "system-interface",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -5629,9 +5046,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c17788f986052fbef69d1af34607d1ef8966481b7ad46accc1b9d73aa16ceb3"
+checksum = "5d845c74073a9c5c2315add0414296d2c1ac5cb2f9a24adf17f9099441fb1ec5"
 dependencies = [
  "anyhow",
  "wasmtime",
@@ -5639,9 +5056,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a63141b184f7e71162a0f9717d7a1e20a22aa0b8d7fc04ec26b9b25679d4745"
+checksum = "489109f6176c32f1038c8c6fe989783acaea79e12ec0ec65b01a6d7d09f7638d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5663,9 +5080,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367b77d382241c7f9b3cde3c8cfc1c0d800f04d665622779a724b71d0a2a2028"
+checksum = "2cceb2d110d8de61e7b0e8c501b838d3c6403a14cdca8cb612ff1228db537c6d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5686,8 +5103,8 @@ dependencies = [
  "http",
  "hyper",
  "num_cpus",
- "oci-client 0.17.0",
- "oci-wasm 0.6.0",
+ "oci-client",
+ "oci-wasm",
  "policy",
  "proptest",
  "reqwest",
@@ -5729,15 +5146,15 @@ dependencies = [
  "hyper",
  "hyper-util",
  "mcp-server",
- "oci-client 0.17.0",
- "oci-wasm 0.4.0",
+ "oci-client",
+ "oci-wasm",
  "policy",
  "proptest",
  "rand 0.9.5",
  "rcgen",
  "reqwest",
  "rmcp",
- "rustls 0.23.40",
+ "rustls 0.23.42",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5788,9 +5205,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5808,9 +5225,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5821,28 +5238,28 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "wiggle"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aed7ef247a05956b0a25e7905fdb709ae89e506547af42897e40301b0658d07"
+checksum = "55a0751406b641ff50ef42d4a1ca843a03040c488c0c27f92093633447464013"
 dependencies = [
  "anyhow",
  "async-trait",
  "bitflags",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "wasmtime",
  "wiggle-macro",
@@ -5850,27 +5267,27 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d5550c5f49730d0a8babd089771ff7412e598cf8f7bbe3b647b8e2147a11b"
+checksum = "ab62083fdcecdd0cac61b8c46e7de4f2629ebe8699fd9ce790d922cc89d50f5f"
 dependencies = [
  "anyhow",
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-macro"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602175405f0c04fd47439ad6afc5e151c4864883259254d3676562bfb00a7ce8"
+checksum = "756b7a4a7f57ee2f53e9ef3501ed0faacda4b8dcb169a921cddc8bc09ebd199e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wiggle-generate",
 ]
 
@@ -5896,7 +5313,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5907,9 +5324,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.10"
+version = "36.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4332c8656af179fb8fc3ae5114c738c29399ee97b638d431725201c17f99294e"
+checksum = "61ec880b20caaa72245944b54cfb22aca111f8c805e12a7542b40d66921e5323"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",
@@ -5918,7 +5335,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasmparser 0.236.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
@@ -5946,7 +5363,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5957,7 +5374,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6181,79 +5598,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser 0.244.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata 0.244.0",
- "wit-bindgen-core",
- "wit-component 0.244.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.244.0",
- "wasm-metadata 0.244.0",
- "wasmparser 0.244.0",
- "wit-parser 0.244.0",
-]
 
 [[package]]
 name = "wit-component"
@@ -6269,7 +5616,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.253.0",
- "wasm-metadata 0.253.0",
+ "wasm-metadata",
  "wasmparser 0.253.0",
  "wit-parser 0.253.0",
 ]
@@ -6290,24 +5637,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.236.1",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -6361,7 +5690,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -6393,9 +5722,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6410,28 +5739,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6451,28 +5780,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6505,14 +5834,14 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ wassette = { path = "crates/wassette" }
 mcp-sdk = "0.0.3"
 mcp-server = { path = "crates/mcp-server" }
 oci-client = "0.17"
-oci-wasm = "0.6"
+oci-wasm = { version = "0.6", default-features = false, features = ["rustls-tls"] }
 policy = { path = "crates/policy" }
 reqwest = { version = "0.13", features = ["stream"] }
-rmcp = "0.9.1"
+rmcp = "1.4.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.9"
@@ -56,7 +56,6 @@ policy = { workspace = true }
 reqwest = { workspace = true }
 rmcp = { workspace = true, features = [
     "server",
-    "transport-sse-server",
     "transport-streamable-http-server",
     "transport-io",
     "macros",
@@ -85,8 +84,8 @@ test-log = { version = "0.2", features = ["trace"] }
 tokio-test = "0.4"
 tracing-test = "0.2"
 testcontainers = "0.27"
-oci-wasm = "0.4"
-oci-client = "0.16"
+oci-wasm = { version = "0.6", default-features = false, features = ["rustls-tls"] }
+oci-client = "0.17"
 hyper = { version = "1.0", features = ["server", "http1"] }
 http-body-util = "0.1"
 hyper-util = "0.1"

--- a/Justfile
+++ b/Justfile
@@ -108,23 +108,23 @@ component2json path="examples/fetch-rs/target/wasm32-wasip2/release/fetch_rs.was
     cargo run --bin component2json -p component2json -- {{ path }}
 
 run RUST_LOG='info':
-    RUST_LOG={{RUST_LOG}} cargo run --bin wassette serve --sse
+    RUST_LOG={{RUST_LOG}} cargo run --bin wassette serve --streamable-http
 
 run-streamable RUST_LOG='info':
     RUST_LOG={{RUST_LOG}} cargo run --bin wassette serve --streamable-http
 
 run-filesystem RUST_LOG='info':
-    RUST_LOG={{RUST_LOG}} cargo run --bin wassette serve --sse --component-dir ./examples/filesystem-rs
+    RUST_LOG={{RUST_LOG}} cargo run --bin wassette serve --streamable-http --component-dir ./examples/filesystem-rs
 
 # Requires an openweather API key in the environment variable OPENWEATHER_API_KEY
 run-get-weather RUST_LOG='info':
-    RUST_LOG={{RUST_LOG}} cargo run --bin wassette serve --sse --component-dir ./examples/get-weather-js
+    RUST_LOG={{RUST_LOG}} cargo run --bin wassette serve --streamable-http --component-dir ./examples/get-weather-js
 
 run-fetch-rs RUST_LOG='info':
-    RUST_LOG={{RUST_LOG}} cargo run --bin wassette serve --sse --component-dir ./examples/fetch-rs
+    RUST_LOG={{RUST_LOG}} cargo run --bin wassette serve --streamable-http --component-dir ./examples/fetch-rs
 
 run-memory RUST_LOG='info':
-    RUST_LOG={{RUST_LOG}} cargo run --bin wassette serve --sse --component-dir ./examples/memory-js
+    RUST_LOG={{RUST_LOG}} cargo run --bin wassette serve --streamable-http --component-dir ./examples/memory-js
 
 # Documentation commands
 docs-build:
@@ -169,4 +169,3 @@ ci-cache-info:
 ci-clean:
     docker rmi $(docker images -q wassette-ci-* 2>/dev/null) 2>/dev/null || true
     docker builder prune -f
-

--- a/crates/component2json/src/lib.rs
+++ b/crates/component2json/src/lib.rs
@@ -1018,7 +1018,7 @@ mod tests {
 
     use super::*;
 
-    fn result_schema<'a>(schema: &'a Value) -> &'a Value {
+    fn result_schema(schema: &Value) -> &Value {
         schema
             .get("properties")
             .and_then(|props| props.get("result"))

--- a/crates/mcp-server/src/components.rs
+++ b/crates/mcp-server/src/components.rs
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use std::borrow::Cow;
 use std::sync::Arc;
 
 use anyhow::Result;
 use futures::stream::{self, StreamExt};
-use rmcp::model::{CallToolRequestParam, CallToolResult, Content, Tool};
+use rmcp::model::{CallToolRequestParams, CallToolResult, Content, Tool};
 use rmcp::{Peer, RoleServer};
 use serde_json::{json, Value};
 use tracing::{debug, error, info, instrument};
@@ -42,7 +41,7 @@ pub(crate) async fn get_component_tools(lifecycle_manager: &LifecycleManager) ->
 
 #[instrument(skip(lifecycle_manager))]
 pub(crate) async fn handle_load_component(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
     server_peer: Peer<RoleServer>,
 ) -> Result<CallToolResult> {
@@ -87,7 +86,7 @@ pub(crate) async fn handle_load_component(
 
 #[instrument(skip(lifecycle_manager))]
 pub(crate) async fn handle_unload_component(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
     server_peer: Peer<RoleServer>,
 ) -> Result<CallToolResult> {
@@ -127,7 +126,7 @@ pub(crate) async fn handle_unload_component(
 
 #[instrument(skip(lifecycle_manager))]
 pub async fn handle_component_call(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
 ) -> Result<CallToolResult> {
     let args = extract_args_from_request(req)?;
@@ -174,12 +173,9 @@ pub async fn handle_component_call(
 
             let contents = vec![Content::text(response_text)];
 
-            Ok(CallToolResult {
-                content: contents,
-                structured_content,
-                is_error: Some(false),
-                meta: None,
-            })
+            let mut result = CallToolResult::success(contents);
+            result.structured_content = structured_content;
+            Ok(result)
         }
         Err(e) => {
             error!(
@@ -276,16 +272,11 @@ pub async fn handle_list_components(
 
     let contents = vec![Content::text(result_text)];
 
-    Ok(CallToolResult {
-        content: contents,
-        structured_content: None,
-        is_error: None,
-        meta: None,
-    })
+    Ok(CallToolResult::success(contents))
 }
 
 pub(crate) fn extract_args_from_request(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
 ) -> Result<serde_json::Map<String, Value>> {
     match &req.arguments {
         Some(args) => {
@@ -313,12 +304,7 @@ fn create_component_success_result(
 
     let contents = vec![Content::text(status_text)];
 
-    Ok(CallToolResult {
-        content: contents,
-        structured_content: None,
-        is_error: None,
-        meta: None,
-    })
+    Ok(CallToolResult::success(contents))
 }
 
 fn create_load_component_success_result(outcome: &ComponentLoadOutcome) -> Result<CallToolResult> {
@@ -335,12 +321,7 @@ fn create_load_component_success_result(outcome: &ComponentLoadOutcome) -> Resul
 
     let contents = vec![Content::text(status_text)];
 
-    Ok(CallToolResult {
-        content: contents,
-        structured_content: None,
-        is_error: None,
-        meta: None,
-    })
+    Ok(CallToolResult::success(contents))
 }
 
 /// Create error result for component operations
@@ -360,12 +341,7 @@ fn create_component_error_result(
 
     let contents = vec![Content::text(error_text)];
 
-    CallToolResult {
-        content: contents,
-        structured_content: None,
-        is_error: Some(true),
-        meta: None,
-    }
+    CallToolResult::error(contents)
 }
 
 /// Handle tool list change notification
@@ -391,7 +367,7 @@ async fn handle_tool_list_notification(
 /// CLI-specific version of handle_load_component that doesn't require server peer notifications
 #[instrument(skip(lifecycle_manager))]
 pub async fn handle_load_component_cli(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
 ) -> Result<CallToolResult> {
     let args = extract_args_from_request(req)?;
@@ -421,7 +397,7 @@ pub async fn handle_load_component_cli(
 /// CLI-specific version of handle_unload_component that doesn't require server peer notifications
 #[instrument(skip(lifecycle_manager))]
 pub async fn handle_unload_component_cli(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
 ) -> Result<CallToolResult> {
     let args = extract_args_from_request(req)?;
@@ -476,15 +452,15 @@ pub(crate) fn parse_tool_schema(tool_json: &Value) -> Option<Tool> {
         "Parsed tool schema"
     );
 
-    Some(Tool {
-        name: Cow::Owned(name.to_string()),
-        description: Some(Cow::Owned(description.to_string())),
-        input_schema: Arc::new(serde_json::from_value(input_schema).unwrap_or_default()),
-        output_schema: output_schema_arc,
-        annotations: None,
-        title: None,
-        icons: None,
-        meta: None,
+    let tool = Tool::new(
+        name.to_string(),
+        description.to_string(),
+        Arc::new(serde_json::from_value(input_schema).unwrap_or_default()),
+    );
+
+    Some(match output_schema_arc {
+        Some(output_schema) => tool.with_raw_output_schema(output_schema),
+        None => tool,
     })
 }
 
@@ -526,13 +502,11 @@ mod tests {
 
     #[test]
     fn test_extract_args_from_request() {
-        let req = CallToolRequestParam {
-            name: "test-tool".into(),
-            arguments: Some(serde_json::Map::from_iter([
+        let req =
+            CallToolRequestParams::new("test-tool").with_arguments(serde_json::Map::from_iter([
                 ("path".to_string(), json!("/test/path")),
                 ("id".to_string(), json!("test-id")),
-            ])),
-        };
+            ]));
 
         let args = extract_args_from_request(&req).unwrap();
         assert_eq!(args.get("path").unwrap(), "/test/path");
@@ -541,10 +515,7 @@ mod tests {
 
     #[test]
     fn test_extract_args_from_request_none() {
-        let req = CallToolRequestParam {
-            name: "test-tool".into(),
-            arguments: None,
-        };
+        let req = CallToolRequestParams::new("test-tool");
 
         let args = extract_args_from_request(&req).unwrap();
         assert!(args.is_empty());

--- a/crates/mcp-server/src/prompts.rs
+++ b/crates/mcp-server/src/prompts.rs
@@ -132,7 +132,7 @@ wit-docs-inject --component target/wasm32-wasip2/release/{component_name}.wasm \
 
 ```bash
 # Start Wassette with your component
-wassette serve --sse --plugin-dir target/wasm32-wasip2/release/
+wassette serve --streamable-http --component-dir target/wasm32-wasip2/release/
 
 # In another terminal, use an MCP client to test
 ```
@@ -328,7 +328,7 @@ wit-docs-inject --component component.wasm \
 
 ```bash
 # Start Wassette with your component
-wassette serve --sse --plugin-dir .
+wassette serve --streamable-http --component-dir .
 
 # In another terminal, use an MCP client to test
 ```

--- a/crates/mcp-server/src/prompts.rs
+++ b/crates/mcp-server/src/prompts.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use rmcp::model::{
-    GetPromptRequestParam, GetPromptResult, ListPromptsResult, Prompt, PromptArgument,
+    GetPromptRequestParams, GetPromptResult, ListPromptsResult, Prompt, PromptArgument,
     PromptMessage, PromptMessageRole,
 };
 
@@ -452,14 +452,14 @@ Would you like me to help you implement any specific functionality for your comp
 pub async fn handle_prompts_list(_req: serde_json::Value) -> Result<serde_json::Value> {
     let response = ListPromptsResult {
         prompts: get_available_prompts(),
-        next_cursor: None,
+        ..Default::default()
     };
     Ok(serde_json::to_value(response)?)
 }
 
 /// Get a specific prompt by name
 pub async fn handle_prompts_get(req: serde_json::Value) -> Result<serde_json::Value> {
-    let parsed_req: GetPromptRequestParam = serde_json::from_value(req)?;
+    let parsed_req: GetPromptRequestParams = serde_json::from_value(req)?;
 
     let prompt_name = parsed_req.name.as_str();
     let arguments = parsed_req.arguments.unwrap_or_default();
@@ -481,22 +481,16 @@ fn get_available_prompts() -> Vec<Prompt> {
         Prompt::new(
             "build-rust-component",
             Some("Guide to building a WebAssembly component for Wassette using Rust"),
-            Some(vec![PromptArgument {
-                name: "component_name".to_string(),
-                title: None,
-                description: Some("The name of the component to build".to_string()),
-                required: Some(false),
-            }]),
+            Some(vec![PromptArgument::new("component_name")
+                .with_description("The name of the component to build")
+                .with_required(false)]),
         ),
         Prompt::new(
             "build-javascript-component",
             Some("Guide to building a WebAssembly component for Wassette using JavaScript"),
-            Some(vec![PromptArgument {
-                name: "component_name".to_string(),
-                title: None,
-                description: Some("The name of the component to build".to_string()),
-                required: Some(false),
-            }]),
+            Some(vec![PromptArgument::new("component_name")
+                .with_description("The name of the component to build")
+                .with_required(false)]),
         ),
     ]
 }
@@ -512,13 +506,14 @@ fn build_rust_component_prompt(
 
     let content = RUST_COMPONENT_TEMPLATE.replace("{component_name}", component_name);
 
-    Ok(GetPromptResult {
-        description: Some(format!(
-            "A step-by-step guide to building a Rust WebAssembly component named '{}'",
-            component_name
-        )),
-        messages: vec![PromptMessage::new_text(PromptMessageRole::User, content)],
-    })
+    Ok(GetPromptResult::new(vec![PromptMessage::new_text(
+        PromptMessageRole::User,
+        content,
+    )])
+    .with_description(format!(
+        "A step-by-step guide to building a Rust WebAssembly component named '{}'",
+        component_name
+    )))
 }
 
 /// Generate the JavaScript component building prompt
@@ -532,13 +527,14 @@ fn build_javascript_component_prompt(
 
     let content = JAVASCRIPT_COMPONENT_TEMPLATE.replace("{component_name}", component_name);
 
-    Ok(GetPromptResult {
-        description: Some(format!(
-            "A step-by-step guide to building a JavaScript WebAssembly component named '{}'",
-            component_name
-        )),
-        messages: vec![PromptMessage::new_text(PromptMessageRole::User, content)],
-    })
+    Ok(GetPromptResult::new(vec![PromptMessage::new_text(
+        PromptMessageRole::User,
+        content,
+    )])
+    .with_description(format!(
+        "A step-by-step guide to building a JavaScript WebAssembly component named '{}'",
+        component_name
+    )))
 }
 
 #[cfg(test)]

--- a/crates/mcp-server/src/resources.rs
+++ b/crates/mcp-server/src/resources.rs
@@ -8,7 +8,7 @@ pub async fn handle_resources_list(req: serde_json::Value) -> Result<serde_json:
     let _parsed_req: ListResourcesRequest = serde_json::from_value(req)?;
     let response = ListResourcesResult {
         resources: vec![],
-        next_cursor: None,
+        ..Default::default()
     };
     Ok(serde_json::to_value(response)?)
 }

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::Result;
-use rmcp::model::{CallToolRequestParam, CallToolResult, Content, Tool};
+use rmcp::model::{CallToolRequestParams, CallToolResult, Content, Tool};
 use rmcp::{Peer, RoleServer};
 use serde_json::{json, Value};
 use tracing::{debug, error, info, instrument, warn};
@@ -36,7 +36,7 @@ pub async fn handle_tools_list(
 
     let response = rmcp::model::ListToolsResult {
         tools,
-        next_cursor: None,
+        ..Default::default()
     };
 
     Ok(serde_json::to_value(response)?)
@@ -110,7 +110,7 @@ fn sanitize_args_for_logging(args: &Option<serde_json::Map<String, Value>>) -> S
 /// Handles a tool call request.
 #[instrument(skip_all, fields(method_name = %req.name))]
 pub async fn handle_tools_call(
-    req: CallToolRequestParam,
+    req: CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
     server_peer: Peer<RoleServer>,
     disable_builtin_tools: bool,
@@ -203,12 +203,7 @@ pub async fn handle_tools_call(
             let error_text = format!("Error: {e}");
             let contents = vec![Content::text(error_text)];
 
-            let error_result = CallToolResult {
-                content: contents,
-                structured_content: None,
-                is_error: Some(true),
-                meta: None,
-            };
+            let error_result = CallToolResult::error(contents);
             Ok(serde_json::to_value(error_result)?)
         }
     }
@@ -217,12 +212,12 @@ pub async fn handle_tools_call(
 fn get_builtin_tools() -> Vec<Tool> {
     debug!("Getting builtin tools");
     vec![
-        Tool {
-            name: Cow::Borrowed("load-component"),
-            description: Some(Cow::Borrowed(
+        Tool::new_with_raw(
+            Cow::Borrowed("load-component"),
+            Some(Cow::Borrowed(
                 "Dynamically loads a new tool or component from either the filesystem or OCI registries.",
             )),
-            input_schema: Arc::new(
+            Arc::new(
                 serde_json::from_value(json!({
                     "type": "object",
                     "properties": {
@@ -232,18 +227,13 @@ fn get_builtin_tools() -> Vec<Tool> {
                 }))
                 .unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            title: None,
-            icons: None,
-            meta: None,
-        },
-        Tool {
-            name: Cow::Borrowed("unload-component"),
-            description: Some(Cow::Borrowed(
+        ),
+        Tool::new_with_raw(
+            Cow::Borrowed("unload-component"),
+            Some(Cow::Borrowed(
                 "Unloads a tool or component.",
             )),
-            input_schema: Arc::new(
+            Arc::new(
                 serde_json::from_value(json!({
                     "type": "object",
                     "properties": {
@@ -253,18 +243,13 @@ fn get_builtin_tools() -> Vec<Tool> {
                 }))
                 .unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            title: None,
-            icons: None,
-            meta: None,
-        },
-        Tool {
-            name: Cow::Borrowed("list-components"),
-            description: Some(Cow::Borrowed(
+        ),
+        Tool::new_with_raw(
+            Cow::Borrowed("list-components"),
+            Some(Cow::Borrowed(
                 "Lists all currently loaded components or tools.",
             )),
-            input_schema: Arc::new(
+            Arc::new(
                 serde_json::from_value(json!({
                     "type": "object",
                     "properties": {},
@@ -272,18 +257,13 @@ fn get_builtin_tools() -> Vec<Tool> {
                 }))
                 .unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            title: None,
-            icons: None,
-            meta: None,
-        },
-        Tool {
-            name: Cow::Borrowed("get-policy"),
-            description: Some(Cow::Borrowed(
+        ),
+        Tool::new_with_raw(
+            Cow::Borrowed("get-policy"),
+            Some(Cow::Borrowed(
                 "Gets the policy information for a specific component",
             )),
-            input_schema: Arc::new(
+            Arc::new(
                 serde_json::from_value(json!({
                     "type": "object",
                     "properties": {
@@ -296,18 +276,13 @@ fn get_builtin_tools() -> Vec<Tool> {
                 }))
                 .unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            title: None,
-            icons: None,
-            meta: None,
-        },
-        Tool {
-            name: Cow::Borrowed("grant-storage-permission"),
-            description: Some(Cow::Borrowed(
+        ),
+        Tool::new_with_raw(
+            Cow::Borrowed("grant-storage-permission"),
+            Some(Cow::Borrowed(
                 "Grants storage access permission to a component, allowing it to read from and/or write to specific storage locations."
             )),
-            input_schema: Arc::new(
+            Arc::new(
                 serde_json::from_value(json!({
                     "type": "object",
                     "properties": {
@@ -339,18 +314,13 @@ fn get_builtin_tools() -> Vec<Tool> {
                   }))
                 .unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            title: None,
-            icons: None,
-            meta: None,
-        },
-        Tool {
-            name: Cow::Borrowed("grant-network-permission"),
-            description: Some(Cow::Borrowed(
+        ),
+        Tool::new_with_raw(
+            Cow::Borrowed("grant-network-permission"),
+            Some(Cow::Borrowed(
                 "Grants network access permission to a component, allowing it to make network requests to specific hosts."
             )),
-            input_schema: Arc::new(
+            Arc::new(
                 serde_json::from_value(json!({
                     "type": "object",
                     "properties": {
@@ -374,18 +344,13 @@ fn get_builtin_tools() -> Vec<Tool> {
                   }))
                 .unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            title: None,
-            icons: None,
-            meta: None,
-        },
-        Tool {
-            name: Cow::Borrowed("grant-environment-variable-permission"),
-            description: Some(Cow::Borrowed(
+        ),
+        Tool::new_with_raw(
+            Cow::Borrowed("grant-environment-variable-permission"),
+            Some(Cow::Borrowed(
                 "Grants environment variable access permission to a component, allowing it to access specific environment variables."
             )),
-            input_schema: Arc::new(
+            Arc::new(
                 serde_json::from_value(json!({
                     "type": "object",
                     "properties": {
@@ -409,18 +374,13 @@ fn get_builtin_tools() -> Vec<Tool> {
                   }))
                 .unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            title: None,
-            icons: None,
-            meta: None,
-        },
-        Tool {
-            name: Cow::Borrowed("revoke-storage-permission"),
-            description: Some(Cow::Borrowed(
+        ),
+        Tool::new_with_raw(
+            Cow::Borrowed("revoke-storage-permission"),
+            Some(Cow::Borrowed(
                 "Revokes all storage access permissions from a component for the specified URI path, removing both read and write access to that location."
             )),
-            input_schema: Arc::new(
+            Arc::new(
                 serde_json::from_value(json!({
                     "type": "object",
                     "properties": {
@@ -444,18 +404,13 @@ fn get_builtin_tools() -> Vec<Tool> {
                   }))
                 .unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            title: None,
-            icons: None,
-            meta: None,
-        },
-        Tool {
-            name: Cow::Borrowed("revoke-network-permission"),
-            description: Some(Cow::Borrowed(
+        ),
+        Tool::new_with_raw(
+            Cow::Borrowed("revoke-network-permission"),
+            Some(Cow::Borrowed(
                 "Revokes network access permission from a component, removing its ability to make network requests to specific hosts."
             )),
-            input_schema: Arc::new(
+            Arc::new(
                 serde_json::from_value(json!({
                     "type": "object",
                     "properties": {
@@ -479,18 +434,13 @@ fn get_builtin_tools() -> Vec<Tool> {
                   }))
                 .unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            title: None,
-            icons: None,
-            meta: None,
-        },
-        Tool {
-            name: Cow::Borrowed("revoke-environment-variable-permission"),
-            description: Some(Cow::Borrowed(
+        ),
+        Tool::new_with_raw(
+            Cow::Borrowed("revoke-environment-variable-permission"),
+            Some(Cow::Borrowed(
                 "Revokes environment variable access permission from a component, removing its ability to access specific environment variables."
             )),
-            input_schema: Arc::new(
+            Arc::new(
                 serde_json::from_value(json!({
                     "type": "object",
                     "properties": {
@@ -514,18 +464,13 @@ fn get_builtin_tools() -> Vec<Tool> {
                   }))
                 .unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            title: None,
-            icons: None,
-            meta: None,
-        },
-        Tool {
-            name: Cow::Borrowed("reset-permission"),
-            description: Some(Cow::Borrowed(
+        ),
+        Tool::new_with_raw(
+            Cow::Borrowed("reset-permission"),
+            Some(Cow::Borrowed(
                 "Resets all permissions for a component, removing all granted permissions and returning it to the default state."
             )),
-            input_schema: Arc::new(
+            Arc::new(
                 serde_json::from_value(json!({
                     "type": "object",
                     "properties": {
@@ -538,18 +483,13 @@ fn get_builtin_tools() -> Vec<Tool> {
                   }))
                 .unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            title: None,
-            icons: None,
-            meta: None,
-        },
-        Tool {
-            name: Cow::Borrowed("search-components"),
-            description: Some(Cow::Borrowed(
+        ),
+        Tool::new_with_raw(
+            Cow::Borrowed("search-components"),
+            Some(Cow::Borrowed(
                 "Lists all known components that can be fetched and loaded. Optionally filter by a search query.",
             )),
-            input_schema: Arc::new(
+            Arc::new(
                 serde_json::from_value(json!({
                     "type": "object",
                     "properties": {
@@ -562,12 +502,7 @@ fn get_builtin_tools() -> Vec<Tool> {
                 }))
                 .unwrap_or_default(),
             ),
-            output_schema: None,
-            annotations: None,
-            title: None,
-            icons: None,
-            meta: None,
-        },
+        ),
     ]
 }
 
@@ -611,7 +546,7 @@ fn calculate_relevance_score(component: &Value, query_terms: &[String]) -> u32 {
 
 #[instrument(skip(_lifecycle_manager))]
 pub(crate) async fn handle_search_component(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     _lifecycle_manager: &LifecycleManager,
 ) -> Result<CallToolResult> {
     let args = extract_args_from_request(req)?;
@@ -666,17 +601,12 @@ pub(crate) async fn handle_search_component(
 
     let contents = vec![Content::text(status_text)];
 
-    Ok(CallToolResult {
-        content: contents,
-        structured_content: None,
-        is_error: None,
-        meta: None,
-    })
+    Ok(CallToolResult::success(contents))
 }
 
 #[instrument(skip(lifecycle_manager))]
 pub async fn handle_get_policy(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
 ) -> Result<CallToolResult> {
     let args = extract_args_from_request(req)?;
@@ -717,17 +647,12 @@ pub async fn handle_get_policy(
 
     let contents = vec![Content::text(status_text)];
 
-    Ok(CallToolResult {
-        content: contents,
-        structured_content: None,
-        is_error: None,
-        meta: None,
-    })
+    Ok(CallToolResult::success(contents))
 }
 
 /// Generic helper for handling grant permission requests
 async fn handle_grant_permission_generic(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
     permission_type: &str,
     permission_display_name: &str,
@@ -769,12 +694,7 @@ async fn handle_grant_permission_generic(
 
             let contents = vec![Content::text(status_text)];
 
-            Ok(CallToolResult {
-                content: contents,
-                structured_content: None,
-                is_error: None,
-                meta: None,
-            })
+            Ok(CallToolResult::success(contents))
         }
         Err(e) => {
             error!(
@@ -793,7 +713,7 @@ async fn handle_grant_permission_generic(
 
 #[instrument(skip(lifecycle_manager))]
 pub async fn handle_grant_storage_permission(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
 ) -> Result<CallToolResult> {
     handle_grant_permission_generic(req, lifecycle_manager, "storage", "storage").await
@@ -801,7 +721,7 @@ pub async fn handle_grant_storage_permission(
 
 #[instrument(skip(lifecycle_manager))]
 pub async fn handle_grant_network_permission(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
 ) -> Result<CallToolResult> {
     handle_grant_permission_generic(req, lifecycle_manager, "network", "network").await
@@ -809,7 +729,7 @@ pub async fn handle_grant_network_permission(
 
 #[instrument(skip(lifecycle_manager))]
 pub async fn handle_grant_environment_variable_permission(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
 ) -> Result<CallToolResult> {
     handle_grant_permission_generic(
@@ -823,7 +743,7 @@ pub async fn handle_grant_environment_variable_permission(
 
 #[instrument(skip(lifecycle_manager))]
 pub async fn handle_grant_memory_permission(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
 ) -> Result<CallToolResult> {
     handle_grant_permission_generic(req, lifecycle_manager, "resource", "memory").await
@@ -831,7 +751,7 @@ pub async fn handle_grant_memory_permission(
 
 /// Generic helper for handling revoke permission requests
 async fn handle_revoke_permission_generic(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
     permission_type: &str,
     permission_display_name: &str,
@@ -872,12 +792,7 @@ async fn handle_revoke_permission_generic(
 
             let contents = vec![Content::text(status_text)];
 
-            Ok(CallToolResult {
-                content: contents,
-                structured_content: None,
-                is_error: None,
-                meta: None,
-            })
+            Ok(CallToolResult::success(contents))
         }
         Err(e) => {
             error!(
@@ -896,7 +811,7 @@ async fn handle_revoke_permission_generic(
 
 #[instrument(skip(lifecycle_manager))]
 pub async fn handle_revoke_storage_permission(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
 ) -> Result<CallToolResult> {
     let args = extract_args_from_request(req)?;
@@ -940,12 +855,7 @@ pub async fn handle_revoke_storage_permission(
 
             let contents = vec![Content::text(status_text)];
 
-            Ok(CallToolResult {
-                content: contents,
-                structured_content: None,
-                is_error: None,
-                meta: None,
-            })
+            Ok(CallToolResult::success(contents))
         }
         Err(e) => {
             error!("Failed to revoke storage permission: {}", e);
@@ -960,7 +870,7 @@ pub async fn handle_revoke_storage_permission(
 
 #[instrument(skip(lifecycle_manager))]
 pub async fn handle_revoke_network_permission(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
 ) -> Result<CallToolResult> {
     handle_revoke_permission_generic(req, lifecycle_manager, "network", "network").await
@@ -968,7 +878,7 @@ pub async fn handle_revoke_network_permission(
 
 #[instrument(skip(lifecycle_manager))]
 pub async fn handle_revoke_environment_variable_permission(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
 ) -> Result<CallToolResult> {
     handle_revoke_permission_generic(
@@ -982,7 +892,7 @@ pub async fn handle_revoke_environment_variable_permission(
 
 #[instrument(skip(lifecycle_manager))]
 pub async fn handle_reset_permission(
-    req: &CallToolRequestParam,
+    req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
 ) -> Result<CallToolResult> {
     let args = extract_args_from_request(req)?;
@@ -1010,12 +920,7 @@ pub async fn handle_reset_permission(
 
             let contents = vec![Content::text(status_text)];
 
-            Ok(CallToolResult {
-                content: contents,
-                structured_content: None,
-                is_error: None,
-                meta: None,
-            })
+            Ok(CallToolResult::success(contents))
         }
         Err(e) => {
             error!("Failed to reset permissions: {}", e);
@@ -1065,10 +970,7 @@ mod tests {
         args.insert("component_id".to_string(), json!("test-component"));
         args.insert("details".to_string(), json!({"host": "api.example.com"}));
 
-        let req = CallToolRequestParam {
-            name: "grant-network-permission".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("grant-network-permission").with_arguments(args);
 
         // This should fail because the component doesn't exist, but it tests the flow
         let result = handle_grant_network_permission(&req, &lifecycle_manager).await;
@@ -1097,10 +999,7 @@ mod tests {
             json!({"uri": "file:///tmp/test", "access": ["read", "write"]}),
         );
 
-        let req = CallToolRequestParam {
-            name: "grant-storage-permission".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("grant-storage-permission").with_arguments(args);
 
         // This should fail because the component doesn't exist, but it tests the flow
         let result = handle_grant_storage_permission(&req, &lifecycle_manager).await;
@@ -1124,10 +1023,7 @@ mod tests {
         let mut args = serde_json::Map::new();
         args.insert("details".to_string(), json!({"host": "api.example.com"}));
 
-        let req = CallToolRequestParam {
-            name: "grant-network-permission".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("grant-network-permission").with_arguments(args);
 
         let result = handle_grant_network_permission(&req, &lifecycle_manager).await;
         assert!(result.is_err());
@@ -1140,10 +1036,7 @@ mod tests {
         let mut args = serde_json::Map::new();
         args.insert("component_id".to_string(), json!("test-component"));
 
-        let req = CallToolRequestParam {
-            name: "grant-network-permission".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("grant-network-permission").with_arguments(args);
 
         let result = handle_grant_network_permission(&req, &lifecycle_manager).await;
         assert!(result.is_err());
@@ -1159,10 +1052,7 @@ mod tests {
             json!({"uri": "file:///tmp/test", "access": ["read"]}),
         );
 
-        let req = CallToolRequestParam {
-            name: "grant-storage-permission".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("grant-storage-permission").with_arguments(args);
 
         let result = handle_grant_storage_permission(&req, &lifecycle_manager).await;
         assert!(result.is_err());
@@ -1175,10 +1065,7 @@ mod tests {
         let mut args = serde_json::Map::new();
         args.insert("component_id".to_string(), json!("test-component"));
 
-        let req = CallToolRequestParam {
-            name: "grant-storage-permission".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("grant-storage-permission").with_arguments(args);
 
         let result = handle_grant_storage_permission(&req, &lifecycle_manager).await;
         assert!(result.is_err());
@@ -1202,10 +1089,7 @@ mod tests {
         args.insert("component_id".to_string(), json!("test-component"));
         args.insert("details".to_string(), json!({"host": "api.example.com"}));
 
-        let req = CallToolRequestParam {
-            name: "revoke-network-permission".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("revoke-network-permission").with_arguments(args);
 
         // This should fail because the component doesn't exist, but it tests the flow
         let result = handle_revoke_network_permission(&req, &lifecycle_manager).await;
@@ -1233,10 +1117,7 @@ mod tests {
             json!({"uri": "fs:///tmp/test", "access": ["read", "write"]}),
         );
 
-        let req = CallToolRequestParam {
-            name: "revoke-storage-permission".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("revoke-storage-permission").with_arguments(args);
 
         // This should fail because the component doesn't exist, but it tests the flow
         let result = handle_revoke_storage_permission(&req, &lifecycle_manager).await;
@@ -1261,10 +1142,8 @@ mod tests {
         args.insert("component_id".to_string(), json!("test-component"));
         args.insert("details".to_string(), json!({"key": "API_KEY"}));
 
-        let req = CallToolRequestParam {
-            name: "revoke-environment-variable-permission".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("revoke-environment-variable-permission")
+            .with_arguments(args);
 
         // This should fail because the component doesn't exist, but it tests the flow
         let result = handle_revoke_environment_variable_permission(&req, &lifecycle_manager).await;
@@ -1288,10 +1167,7 @@ mod tests {
         let mut args = serde_json::Map::new();
         args.insert("component_id".to_string(), json!("test-component"));
 
-        let req = CallToolRequestParam {
-            name: "reset-permission".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("reset-permission").with_arguments(args);
 
         // This should fail because the component doesn't exist, but it tests the flow
         let result = handle_reset_permission(&req, &lifecycle_manager).await;
@@ -1315,10 +1191,7 @@ mod tests {
         let mut args = serde_json::Map::new();
         args.insert("details".to_string(), json!({"host": "api.example.com"}));
 
-        let req = CallToolRequestParam {
-            name: "revoke-network-permission".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("revoke-network-permission").with_arguments(args);
 
         let result = handle_revoke_network_permission(&req, &lifecycle_manager).await;
         assert!(result.is_err());
@@ -1331,10 +1204,7 @@ mod tests {
         let mut args = serde_json::Map::new();
         args.insert("component_id".to_string(), json!("test-component"));
 
-        let req = CallToolRequestParam {
-            name: "revoke-network-permission".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("revoke-network-permission").with_arguments(args);
 
         let result = handle_revoke_network_permission(&req, &lifecycle_manager).await;
         assert!(result.is_err());
@@ -1346,10 +1216,7 @@ mod tests {
         // Test with missing component_id for reset permission
         let args = serde_json::Map::new();
 
-        let req = CallToolRequestParam {
-            name: "reset-permission".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("reset-permission").with_arguments(args);
 
         let result = handle_reset_permission(&req, &lifecycle_manager).await;
         assert!(result.is_err());
@@ -1425,10 +1292,7 @@ mod tests {
 
         // Test without query - should return all components
         let args = serde_json::Map::new();
-        let req = CallToolRequestParam {
-            name: "search-components".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("search-components").with_arguments(args);
 
         let result = handle_search_component(&req, &lifecycle_manager).await?;
 
@@ -1459,10 +1323,7 @@ mod tests {
         // Test with query - search for "weather"
         let mut args = serde_json::Map::new();
         args.insert("query".to_string(), json!("weather"));
-        let req = CallToolRequestParam {
-            name: "search-components".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("search-components").with_arguments(args);
 
         let result = handle_search_component(&req, &lifecycle_manager).await?;
 
@@ -1511,10 +1372,7 @@ mod tests {
         // Test case insensitivity - search with uppercase
         let mut args = serde_json::Map::new();
         args.insert("query".to_string(), json!("WEATHER"));
-        let req = CallToolRequestParam {
-            name: "search-components".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("search-components").with_arguments(args);
 
         let result = handle_search_component(&req, &lifecycle_manager).await?;
 
@@ -1542,10 +1400,7 @@ mod tests {
         // Test with query that matches nothing
         let mut args = serde_json::Map::new();
         args.insert("query".to_string(), json!("nonexistent"));
-        let req = CallToolRequestParam {
-            name: "search-components".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("search-components").with_arguments(args);
 
         let result = handle_search_component(&req, &lifecycle_manager).await?;
 
@@ -1573,10 +1428,7 @@ mod tests {
         // Test multi-term search
         let mut args = serde_json::Map::new();
         args.insert("query".to_string(), json!("weather rust"));
-        let req = CallToolRequestParam {
-            name: "search-components".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("search-components").with_arguments(args);
 
         let result = handle_search_component(&req, &lifecycle_manager).await?;
 
@@ -1608,10 +1460,7 @@ mod tests {
         // Other components might have it in description
         let mut args = serde_json::Map::new();
         args.insert("query".to_string(), json!("server"));
-        let req = CallToolRequestParam {
-            name: "search-components".into(),
-            arguments: Some(args),
-        };
+        let req = CallToolRequestParams::new("search-components").with_arguments(args);
 
         let result = handle_search_component(&req, &lifecycle_manager).await?;
 
@@ -1652,10 +1501,8 @@ mod tests {
         let lifecycle_manager = wassette::LifecycleManager::new(&tempdir).await?;
 
         // Test 1: No query returns all components
-        let req1 = CallToolRequestParam {
-            name: "search-components".into(),
-            arguments: Some(serde_json::Map::new()),
-        };
+        let req1 =
+            CallToolRequestParams::new("search-components").with_arguments(serde_json::Map::new());
         let result1 = handle_search_component(&req1, &lifecycle_manager).await?;
         let content1_json = serde_json::to_value(&result1.content)?;
         let text1 = content1_json[0]["text"].as_str().unwrap();
@@ -1665,10 +1512,7 @@ mod tests {
         // Test 2: Query with single term
         let mut args2 = serde_json::Map::new();
         args2.insert("query".to_string(), json!("python"));
-        let req2 = CallToolRequestParam {
-            name: "search-components".into(),
-            arguments: Some(args2),
-        };
+        let req2 = CallToolRequestParams::new("search-components").with_arguments(args2);
         let result2 = handle_search_component(&req2, &lifecycle_manager).await?;
         let content2_json = serde_json::to_value(&result2.content)?;
         let text2 = content2_json[0]["text"].as_str().unwrap();
@@ -1680,10 +1524,7 @@ mod tests {
         // Test 3: Query with no matches
         let mut args3 = serde_json::Map::new();
         args3.insert("query".to_string(), json!("xyz123notfound"));
-        let req3 = CallToolRequestParam {
-            name: "search-components".into(),
-            arguments: Some(args3),
-        };
+        let req3 = CallToolRequestParams::new("search-components").with_arguments(args3);
         let result3 = handle_search_component(&req3, &lifecycle_manager).await?;
         let content3_json = serde_json::to_value(&result3.content)?;
         let text3 = content3_json[0]["text"].as_str().unwrap();
@@ -1693,10 +1534,7 @@ mod tests {
         // Test 4: Verify ranking - exact name match should come first
         let mut args4 = serde_json::Map::new();
         args4.insert("query".to_string(), json!("fetch"));
-        let req4 = CallToolRequestParam {
-            name: "search-components".into(),
-            arguments: Some(args4),
-        };
+        let req4 = CallToolRequestParams::new("search-components").with_arguments(args4);
         let result4 = handle_search_component(&req4, &lifecycle_manager).await?;
         let content4_json = serde_json::to_value(&result4.content)?;
         let text4 = content4_json[0]["text"].as_str().unwrap();

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 use std::borrow::Cow;
+use std::cmp::Reverse;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -582,7 +583,7 @@ pub(crate) async fn handle_search_component(
                 .collect();
 
             // Sort by relevance score (descending)
-            scored_components.sort_by(|a, b| b.0.cmp(&a.0));
+            scored_components.sort_by_key(|entry| Reverse(entry.0));
 
             // Extract components in ranked order
             scored_components

--- a/crates/wassette/src/component_storage.rs
+++ b/crates/wassette/src/component_storage.rs
@@ -4,7 +4,7 @@
 //! Filesystem helpers that manage component artifacts, metadata, and cache
 //! layout for the lifecycle manager.
 
-use std::io::BufReader;
+use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -294,10 +294,17 @@ async fn compute_file_hash(path: &Path) -> Result<String> {
     spawn_blocking(move || -> Result<String> {
         let mut reader = BufReader::new(file);
         let mut hasher = Sha256::new();
+        let mut buffer = [0; 8192];
 
-        std::io::copy(&mut reader, &mut hasher)?;
+        loop {
+            let bytes_read = reader.read(&mut buffer)?;
+            if bytes_read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..bytes_read]);
+        }
 
-        Ok(format!("{:x}", hasher.finalize()))
+        Ok(hex::encode(hasher.finalize()))
     })
     .await?
     .with_context(|| format!("Failed to hash file {}", path.display()))

--- a/crates/wassette/src/policy_internal.rs
+++ b/crates/wassette/src/policy_internal.rs
@@ -679,10 +679,8 @@ impl PolicyManager {
                 // Note: access can be empty for revocation operations, but not for grant operations
                 // The validation for non-empty access is now done during parsing
             }
-            PermissionRule::Environment(env) => {
-                if env.key.is_empty() {
-                    return Err(anyhow!("Environment variable key cannot be empty"));
-                }
+            PermissionRule::Environment(env) if env.key.is_empty() => {
+                return Err(anyhow!("Environment variable key cannot be empty"));
             }
             _ => {}
         }

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -110,7 +110,7 @@ Once you've built a component, you can test it with Wassette:
 
 ```bash
 # Load and test your component
-wassette serve --sse --component-dir /path/to/your/component
+wassette serve --streamable-http --component-dir /path/to/your/component
 
 # Or load it explicitly
 wassette load file:///path/to/your/component.wasm

--- a/docs/cookbook/documenting-wit.md
+++ b/docs/cookbook/documenting-wit.md
@@ -223,7 +223,7 @@ fetch, Some("Fetch data from a URL and return the response body as a String")
 When you load this component in Wassette:
 
 ```bash
-wassette serve --sse --component-dir examples/fetch-rs
+wassette serve --streamable-http --component-dir examples/fetch-rs
 ```
 
 The AI agent sees a tool with the description from your WIT documentation:

--- a/docs/cookbook/go.md
+++ b/docs/cookbook/go.md
@@ -112,7 +112,7 @@ For more information, see the [Documenting WIT Interfaces](./documenting-wit.md)
 ### 7. Test Your Component
 
 ```bash
-wassette serve --sse --component-dir .
+wassette serve --streamable-http --component-dir .
 ```
 
 ## Complete Examples
@@ -442,7 +442,7 @@ clean:
 
 # Test the component
 test: build
-    wassette serve --sse --component-dir .
+    wassette serve --streamable-http --component-dir .
 ```
 
 Usage:

--- a/docs/cookbook/javascript.md
+++ b/docs/cookbook/javascript.md
@@ -118,7 +118,7 @@ For more information, see the [Documenting WIT Interfaces](./documenting-wit.md)
 ### 7. Test Your Component
 
 ```bash
-wassette serve --sse --component-dir .
+wassette serve --streamable-http --component-dir .
 ```
 
 ## Complete Examples

--- a/docs/cookbook/python.md
+++ b/docs/cookbook/python.md
@@ -147,7 +147,7 @@ For more information, see the [Documenting WIT Interfaces](./documenting-wit.md)
 ### 8. Test Your Component
 
 ```bash
-wassette serve --sse --component-dir .
+wassette serve --streamable-http --component-dir .
 ```
 
 ## Complete Examples

--- a/docs/cookbook/rust.md
+++ b/docs/cookbook/rust.md
@@ -5,7 +5,7 @@ This cookbook guide shows you how to build WebAssembly components using Rust tha
 ## Quick Start
 
 ### Prerequisites
-- Rust toolchain (1.75.0 or later)
+- Rust toolchain (1.97.1 or later)
 - WASI Preview 2 target
 
 ### Install Tools

--- a/docs/cookbook/rust.md
+++ b/docs/cookbook/rust.md
@@ -133,7 +133,7 @@ For more information, see the [Documenting WIT Interfaces](./documenting-wit.md)
 ### 8. Test Your Component
 
 ```bash
-wassette serve --sse --component-dir target/wasm32-wasip2/release/
+wassette serve --streamable-http --component-dir target/wasm32-wasip2/release/
 ```
 
 ## Complete Examples

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -298,7 +298,7 @@ docker run --rm -p 9001:9001 \
 If you need a custom base image:
 
 ```dockerfile
-FROM rust:1.90-bookworm AS builder
+FROM rust:1.97.1-bookworm AS builder
 # ... build stage ...
 
 FROM your-custom-base:latest

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -54,7 +54,7 @@ docker run -i --rm wassette:latest wassette run
 For SSE transport, override the default command:
 
 ```bash
-docker run --rm -p 9001:9001 wassette:latest wassette serve --sse
+docker run --rm -p 9001:9001 wassette:latest wassette serve --streamable-http
 ```
 
 Then connect to `http://localhost:9001/sse` from your MCP client.
@@ -386,7 +386,7 @@ When using HTTP/SSE transport, ensure the port is properly exposed:
 
 ```bash
 # Check if the port is listening
-docker run -d --name wassette-test -p 9001:9001 wassette:latest wassette serve --sse
+docker run -d --name wassette-test -p 9001:9001 wassette:latest wassette serve --streamable-http
 docker logs wassette-test
 curl http://localhost:9001/sse
 docker rm -f wassette-test

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -21,7 +21,7 @@ Quick guide for contributing to Wassette.
 **Required:**
 
 ```bash
-# Install Rust (1.90+)
+# Install Rust (1.97.1+)
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source ~/.cargo/env
 

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -105,7 +105,7 @@ cargo clippy --workspace --fix
 ## Running the Development Server
 
 ```bash
-# Start server (127.0.0.1:9001/sse)
+# Start the Streamable HTTP server (127.0.0.1:9001/mcp)
 just run
 
 # Custom log level (error, warn, info, debug, trace)
@@ -117,9 +117,9 @@ just run-fetch-rs
 just run-get-weather  # Requires OPENWEATHER_API_KEY
 
 # Debug with MCP Inspector
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/list
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse --method tools/call --tool-name tool-name --tool-arg param=value
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/list
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http --method tools/call --tool-name tool-name --tool-arg param=value
 ```
 
 ## Building Documentation

--- a/docs/development/go.md
+++ b/docs/development/go.md
@@ -288,11 +288,11 @@ func myFunction(input string) MyResult {
 1. Build your component
 2. Start Wassette with your component:
    ```bash
-   wassette serve --sse --component-dir ./
+   wassette serve --streamable-http --component-dir ./
    ```
 3. Connect using the MCP inspector:
    ```bash
-   npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse
+   npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http
    ```
 
 ### Unit Testing

--- a/docs/development/javascript.md
+++ b/docs/development/javascript.md
@@ -511,12 +511,12 @@ world my-component {
 2. **Test with Wassette:**
    ```bash
    # Start Wassette with your component directory
-   wassette serve --sse --component-dir .
+   wassette serve --streamable-http --component-dir .
    ```
 
 3. **Use the MCP Inspector to test:**
    ```bash
-   npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse
+   npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http
    ```
 
 ### Debugging Techniques

--- a/docs/development/python.md
+++ b/docs/development/python.md
@@ -224,7 +224,7 @@ You can test your component using Wassette:
 
 ```bash
 # Start Wassette with your component
-wassette serve --sse --component-dir .
+wassette serve --streamable-http --component-dir .
 
 # Or load it explicitly
 wassette load file://./calculator.wasm
@@ -377,10 +377,10 @@ Test your component with Wassette:
 just build
 
 # Start Wassette with your component
-wassette serve --sse --component-dir .
+wassette serve --streamable-http --component-dir .
 
 # In another terminal, test with MCP inspector
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http
 ```
 
 ## Deployment and Distribution

--- a/docs/development/rust.md
+++ b/docs/development/rust.md
@@ -588,7 +588,7 @@ Test your component with Wassette locally:
 cargo build --target wasm32-wasip2 --release
 
 # Start Wassette with your component
-wassette serve --sse --component-dir .
+wassette serve --streamable-http --component-dir .
 ```
 
 ### 3. Component Inspection

--- a/docs/development/rust.md
+++ b/docs/development/rust.md
@@ -20,7 +20,7 @@ This guide provides comprehensive instructions for creating WebAssembly (Wasm) c
 
 Before you begin, ensure you have the following installed:
 
-1. **Rust toolchain** (1.75.0 or later):
+1. **Rust toolchain** (1.97.1 or later):
    ```bash
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
    source ~/.cargo/env

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -111,7 +111,7 @@ For users who prefer Nix for reproducible environments (works on all platforms):
 
 ```bash
 # Run directly without installation
-nix run github:microsoft/wassette -- serve --stdio
+nix run github:microsoft/wassette -- run
 
 # Install to your profile
 nix profile install github:microsoft/wassette

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -545,8 +545,8 @@ wassette permission grant memory my-tool 512Mi
 # 5. Verify permissions
 wassette policy get my-tool --output-format yaml
 
-# 6. Test via MCP server
-wassette serve --stdio
+# 6. Test via the local stdio MCP server
+wassette run
 ```
 
 ### Component Discovery and Installation
@@ -572,8 +572,8 @@ wassette permission grant memory weather-server 256Mi
 wassette component list --output-format table
 wassette policy get weather-server --output-format yaml
 
-# 7. Start the MCP server
-wassette serve --stdio
+# 7. Start the local stdio MCP server
+wassette run
 ```
 
 ### Component Distribution
@@ -587,8 +587,8 @@ wassette permission grant storage my-tool fs://workspace/** --access read,write
 wassette permission grant network my-tool api.myservice.com
 wassette permission grant memory my-tool 1Gi
 
-# 3. Start server for clients
-wassette serve --sse
+# 3. Start the Streamable HTTP server for remote clients
+wassette serve --streamable-http
 ```
 
 ### Permission Auditing

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -85,32 +85,23 @@ wassette run --component-dir /custom/components
 
 ### `wassette serve`
 
-Start the Wassette MCP server with HTTP transports for remote access. This is intended for remote deployment scenarios.
-
-**Server-Sent Events (SSE) transport:**
-```bash
-# Start server with SSE transport (default)
-wassette serve
-
-# Use SSE with custom bind address
-wassette serve --sse --bind-address 0.0.0.0:8080
-
-# Use environment variables for bind address
-export PORT=8080
-export BIND_HOST=0.0.0.0
-wassette serve --sse
-```
+Start the Wassette MCP server with Streamable HTTP for remote access. This is intended for remote deployment scenarios.
 
 **Streamable HTTP transport:**
 ```bash
-# Start server with streamable HTTP transport
+# Start server with Streamable HTTP transport
+wassette serve
+
+# The explicit compatibility flag is also supported
 wassette serve --streamable-http
+
+# Use a custom bind address
+wassette serve --bind-address 0.0.0.0:8080
 ```
 
 **Options:**
-- `--sse`: Use Server-Sent Events transport (default)
-- `--streamable-http`: Use streamable HTTP transport
-- `--bind-address <ADDRESS>`: Set bind address for HTTP transports (default: `127.0.0.1:9001`)
+- `--streamable-http`: Explicitly select Streamable HTTP transport
+- `--bind-address <ADDRESS>`: Set the bind address (default: `127.0.0.1:9001`)
 - `--component-dir <PATH>`: Set component storage directory (default: `$XDG_DATA_HOME/wassette/components`)
 - `--env <KEY=VALUE>`: Set environment variables (can be specified multiple times)
 - `--env-file <PATH>`: Load environment variables from a file

--- a/docs/reference/configuration-files.md
+++ b/docs/reference/configuration-files.md
@@ -110,7 +110,7 @@ export BIND_HOST=0.0.0.0
 export WASSETTE_CONFIG_FILE=/etc/wassette/config.toml
 
 # Start server
-wassette serve --sse
+wassette serve --streamable-http
 ```
 
 ## See Also

--- a/examples/arxiv-rs/README.md
+++ b/examples/arxiv-rs/README.md
@@ -124,7 +124,7 @@ Start the MCP server and interact with it via the MCP Inspector:
 cargo run --release -- serve mcp sse
 
 # In another terminal, use MCP inspector
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http
 ```
 
 ## Examples

--- a/examples/brave-search-rs/README.md
+++ b/examples/brave-search-rs/README.md
@@ -65,7 +65,7 @@ export BRAVE_SEARCH_API_KEY=your_api_key_here
 cargo run --release -- serve mcp sse
 
 # In another terminal, use MCP inspector to call the tool
-npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/sse
+npx @modelcontextprotocol/inspector --cli http://127.0.0.1:9001/mcp --transport http
 ```
 
 The component will return formatted markdown with web and news results.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.90"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-wasip2", "wasm32-wasip1"]

--- a/scripts/validate-component-registry.sh
+++ b/scripts/validate-component-registry.sh
@@ -87,10 +87,10 @@ echo "Found $VALIDATE_COUNT component(s) to validate:"
 cat "$NEW_OR_MODIFIED" | sed 's/^/  - /'
 echo ""
 
-# Start wassette server in background with SSE transport
+# Start wassette server in background with Streamable HTTP transport
 WASSETTE_LOG="$TMP_DIR/wassette.log"
 echo "Starting wassette server..."
-RUST_LOG=warn "$WASSETTE_BIN" serve --sse > "$WASSETTE_LOG" 2>&1 &
+RUST_LOG=warn "$WASSETTE_BIN" serve --streamable-http > "$WASSETTE_LOG" 2>&1 &
 WASSETTE_PID=$!
 
 # Wait for server to be ready
@@ -98,9 +98,7 @@ echo "Waiting for wassette server to start..."
 MAX_WAIT=30
 WAITED=0
 while [[ $WAITED -lt $MAX_WAIT ]]; do
-    # Check if the SSE endpoint is available (returns 200 with event-stream)
-    # Use HEAD request (-I) to avoid hanging on the streaming response
-    if timeout 2 curl -s -I http://127.0.0.1:9001/sse 2>/dev/null | grep -q "HTTP/1.1 200"; then
+    if timeout 2 curl --fail --silent http://127.0.0.1:9001/ready >/dev/null 2>&1; then
         echo "Wassette server is ready (PID: $WASSETTE_PID)"
         break
     fi
@@ -144,11 +142,11 @@ while IFS= read -r uri; do
     # Attempt to load the component using MCP protocol
     LOAD_RESULT="$TMP_DIR/load-result.json"
     if npx -y @modelcontextprotocol/inspector \
-        --transport sse \
-        --url http://127.0.0.1:9001/sse \
-        tools call \
-        --name load-component \
-        --arguments "{\"path\":\"$uri\"}" > "$LOAD_RESULT" 2>&1; then
+        --cli http://127.0.0.1:9001/mcp \
+        --transport http \
+        --method tools/call \
+        --tool-name load-component \
+        --tool-arg "path=$uri" > "$LOAD_RESULT" 2>&1; then
 
         # Check if the result indicates success
         if jq -e '.content[0].text | contains("component loaded successfully") or contains("component reloaded successfully")' "$LOAD_RESULT" > /dev/null 2>&1; then

--- a/src/cli_handlers.rs
+++ b/src/cli_handlers.rs
@@ -17,7 +17,7 @@ use mcp_server::tools::{
     handle_revoke_storage_permission,
 };
 use mcp_server::LifecycleManager;
-use rmcp::model::CallToolRequestParam;
+use rmcp::model::CallToolRequestParams;
 use serde_json::{Map, Value};
 
 use crate::config;
@@ -33,10 +33,7 @@ pub async fn handle_tool_cli_command(
 ) -> Result<()> {
     let tool = ToolName::try_from(tool_name)?;
 
-    let req = CallToolRequestParam {
-        name: tool.as_str().to_string().into(),
-        arguments: Some(args),
-    };
+    let req = CallToolRequestParams::new(tool.as_str().to_string()).with_arguments(args);
 
     let result = match tool {
         ToolName::LoadComponent => handle_load_component_cli(&req, lifecycle_manager).await?,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -49,7 +49,7 @@ pub struct Cli {
 pub enum Commands {
     /// Run locally with stdio transport (for local development and testing).
     Run(Run),
-    /// Serve remotely over HTTP transports (SSE or StreamableHttp).
+    /// Serve remotely over Streamable HTTP.
     Serve(Serve),
     /// Manage WebAssembly components.
     Component {
@@ -147,7 +147,7 @@ pub struct Serve {
     #[serde(default)]
     pub disable_builtin_tools: bool,
 
-    /// Bind address for HTTP-based transports (SSE and StreamableHttp). Defaults to 127.0.0.1:9001
+    /// Bind address for Streamable HTTP. Defaults to 127.0.0.1:9001
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bind_address: Option<String>,
@@ -162,12 +162,7 @@ pub struct Serve {
 #[derive(Args, Debug, Clone, Serialize, Deserialize, Default)]
 #[group(required = false, multiple = false)]
 pub struct HttpTransportFlags {
-    /// Serving with SSE transport
-    #[arg(long)]
-    #[serde(skip)]
-    pub sse: bool,
-
-    /// Serving with streamable HTTP transport  
+    /// Serving with Streamable HTTP transport
     #[arg(long)]
     #[serde(skip)]
     pub streamable_http: bool,
@@ -175,17 +170,12 @@ pub struct HttpTransportFlags {
 
 #[derive(Debug)]
 pub enum Transport {
-    Sse,
     StreamableHttp,
 }
 
 impl From<&HttpTransportFlags> for Transport {
-    fn from(f: &HttpTransportFlags) -> Self {
-        match (f.sse, f.streamable_http) {
-            (true, false) => Transport::Sse,
-            (false, true) => Transport::StreamableHttp,
-            _ => Transport::Sse, // Default case: use SSE transport for serve
-        }
+    fn from(_flags: &HttpTransportFlags) -> Self {
+        Transport::StreamableHttp
     }
 }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -9,20 +9,15 @@ use rmcp::model::CallToolResult;
 use serde_json::{Map, Value};
 
 /// Output format options for CLI commands
-#[derive(Debug, Clone, Copy, PartialEq, ValueEnum)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, ValueEnum)]
 pub enum OutputFormat {
     /// JSON format
+    #[default]
     Json,
     /// YAML format
     Yaml,
     /// Table format
     Table,
-}
-
-impl Default for OutputFormat {
-    fn default() -> Self {
-        Self::Json
-    }
 }
 
 /// Format a JSON value as YAML string

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-pub use {mcp_server, wassette};
+pub use mcp_server;
+pub use wassette;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-pub use mcp_server;
-pub use wassette;
+pub use {mcp_server, wassette};

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,9 @@ use clap::{CommandFactory, Parser};
 use clap_complete::{generate, shells};
 use mcp_server::{handle_tools_list, LifecycleManager};
 use rmcp::service::serve_server;
+use rmcp::transport::stdio as stdio_transport;
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
 use rmcp::transport::streamable_http_server::StreamableHttpService;
-use rmcp::transport::{stdio as stdio_transport, SseServer};
 use serde_json::{json, Map};
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
@@ -298,28 +298,6 @@ async fn main() -> Result<()> {
 
                         // Wait for the server task to complete
                         let _ = server_handle.await;
-                    }
-                    Transport::Sse => {
-                        tracing::info!(
-                        "Starting MCP server on {} with SSE HTTP transport. Components will load in the background.",
-                        bind_address
-                    );
-
-                        let ct = SseServer::serve(bind_address.parse().unwrap())
-                            .await?
-                            .with_service(move || server.clone());
-
-                        tracing::info!(
-                            "MCP server is ready and listening on http://{}/sse",
-                            bind_address
-                        );
-                        tracing::info!(
-                            "Note: Health endpoints (/health, /ready, /info) are only available with --streamable-http transport. \
-                            SSE transport is designed solely for event streaming and does not provide a general HTTP request/response interface."
-                        );
-
-                        tokio::signal::ctrl_c().await?;
-                        ct.cancel();
                     }
                 }
 
@@ -625,17 +603,12 @@ async fn main() -> Result<()> {
                     };
 
                     print_result(
-                        &rmcp::model::CallToolResult {
-                            content: vec![rmcp::model::Content::text(
-                                serde_json::to_string_pretty(&json!({
-                                    "component_id": component_id,
-                                    "secrets": result
-                                }))?,
-                            )],
-                            structured_content: None,
-                            is_error: None,
-                            meta: None,
-                        },
+                        &rmcp::model::CallToolResult::success(vec![rmcp::model::Content::text(
+                            serde_json::to_string_pretty(&json!({
+                                "component_id": component_id,
+                                "secrets": result
+                            }))?,
+                        )]),
                         *output_format,
                     )?;
                 }
@@ -656,14 +629,9 @@ async fn main() -> Result<()> {
                     });
 
                     print_result(
-                        &rmcp::model::CallToolResult {
-                            content: vec![rmcp::model::Content::text(
-                                serde_json::to_string_pretty(&result)?,
-                            )],
-                            structured_content: None,
-                            is_error: None,
-                            meta: None,
-                        },
+                        &rmcp::model::CallToolResult::success(vec![rmcp::model::Content::text(
+                            serde_json::to_string_pretty(&result)?,
+                        )]),
                         OutputFormat::Json,
                     )?;
                 }
@@ -684,14 +652,9 @@ async fn main() -> Result<()> {
                     });
 
                     print_result(
-                        &rmcp::model::CallToolResult {
-                            content: vec![rmcp::model::Content::text(
-                                serde_json::to_string_pretty(&result)?,
-                            )],
-                            structured_content: None,
-                            is_error: None,
-                            meta: None,
-                        },
+                        &rmcp::model::CallToolResult::success(vec![rmcp::model::Content::text(
+                            serde_json::to_string_pretty(&result)?,
+                        )]),
                         OutputFormat::Json,
                     )?;
                 }
@@ -721,12 +684,9 @@ async fn main() -> Result<()> {
                     }))?;
 
                     print_result(
-                        &rmcp::model::CallToolResult {
-                            content: vec![rmcp::model::Content::text(content)],
-                            structured_content: None,
-                            is_error: None,
-                            meta: None,
-                        },
+                        &rmcp::model::CallToolResult::success(vec![rmcp::model::Content::text(
+                            content,
+                        )]),
                         *output_format,
                     )?;
                 }
@@ -756,12 +716,9 @@ async fn main() -> Result<()> {
                     }))?;
 
                     print_result(
-                        &rmcp::model::CallToolResult {
-                            content: vec![rmcp::model::Content::text(content)],
-                            structured_content: None,
-                            is_error: None,
-                            meta: None,
-                        },
+                        &rmcp::model::CallToolResult::success(vec![rmcp::model::Content::text(
+                            content,
+                        )]),
                         *output_format,
                     )?;
                 }
@@ -796,10 +753,8 @@ async fn main() -> Result<()> {
                         )
                         .await?;
                     } else {
-                        let req = rmcp::model::CallToolRequestParam {
-                            name: name.clone().into(),
-                            arguments: Some(arguments),
-                        };
+                        let req = rmcp::model::CallToolRequestParams::new(name.clone())
+                            .with_arguments(arguments);
 
                         use mcp_server::components::handle_component_call;
                         let result = handle_component_call(&req, &lifecycle_manager).await;
@@ -879,14 +834,9 @@ async fn main() -> Result<()> {
                     });
 
                     print_result(
-                        &rmcp::model::CallToolResult {
-                            content: vec![rmcp::model::Content::text(
-                                serde_json::to_string_pretty(&result)?,
-                            )],
-                            structured_content: None,
-                            is_error: None,
-                            meta: None,
-                        },
+                        &rmcp::model::CallToolResult::success(vec![rmcp::model::Content::text(
+                            serde_json::to_string_pretty(&result)?,
+                        )]),
                         *output_format,
                     )?;
                 }
@@ -995,7 +945,7 @@ mod cli_tests {
         matches!(cli.command, Some(Commands::Run(_)));
 
         // Test serve command (remote HTTP)
-        let args = vec!["wassette", "serve", "--sse"];
+        let args = vec!["wassette", "serve"];
         let cli = Cli::try_parse_from(args).unwrap();
         matches!(cli.command, Some(Commands::Serve(_)));
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,8 +12,8 @@ use mcp_server::{
     LifecycleManager,
 };
 use rmcp::model::{
-    CallToolRequestParam, CallToolResult, ErrorData, ListPromptsResult, ListResourcesResult,
-    ListToolsResult, PaginatedRequestParam, ServerCapabilities, ServerInfo, ToolsCapability,
+    CallToolRequestParams, CallToolResult, ErrorData, ListPromptsResult, ListResourcesResult,
+    ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo,
 };
 use rmcp::service::{RequestContext, RoleServer};
 use rmcp::ServerHandler;
@@ -57,15 +57,13 @@ impl McpServer {
 #[allow(refining_impl_trait_reachable)]
 impl ServerHandler for McpServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            capabilities: ServerCapabilities {
-                tools: Some(ToolsCapability {
-                    list_changed: Some(true),
-                }),
-                ..Default::default()
-            },
-            instructions: Some(
-                r#"This server runs tools in sandboxed WebAssembly environments with no default access to host resources.
+        let mut info = ServerInfo::default();
+        info.capabilities = ServerCapabilities::builder()
+            .enable_tools()
+            .enable_tool_list_changed()
+            .build();
+        info.instructions = Some(
+            r#"This server runs tools in sandboxed WebAssembly environments with no default access to host resources.
 
 Key points:
 - Tools must be loaded before use: "Load component from oci://registry/tool:version" or "file:///path/to/tool.wasm"
@@ -75,14 +73,13 @@ Key points:
 - You MUST never modify the policy file directly, use tools to grant permissions instead.
 - Tools needs permission for that resource
 - If access is denied, suggest alternatives within allowed permissions or propose to grant permission"#.to_string(),
-            ),
-            ..Default::default()
-        }
+        );
+        info
     }
 
     fn call_tool<'a>(
         &'a self,
-        params: CallToolRequestParam,
+        params: CallToolRequestParams,
         ctx: RequestContext<RoleServer>,
     ) -> Pin<Box<dyn Future<Output = Result<CallToolResult, ErrorData>> + Send + 'a>> {
         let peer_clone = ctx.peer.clone();
@@ -110,7 +107,7 @@ Key points:
 
     fn list_tools<'a>(
         &'a self,
-        _params: Option<PaginatedRequestParam>,
+        _params: Option<PaginatedRequestParams>,
         ctx: RequestContext<RoleServer>,
     ) -> Pin<Box<dyn Future<Output = Result<ListToolsResult, ErrorData>> + Send + 'a>> {
         // Store peer on first request
@@ -130,7 +127,7 @@ Key points:
 
     fn list_prompts<'a>(
         &'a self,
-        _params: Option<PaginatedRequestParam>,
+        _params: Option<PaginatedRequestParams>,
         ctx: RequestContext<RoleServer>,
     ) -> Pin<Box<dyn Future<Output = Result<ListPromptsResult, ErrorData>> + Send + 'a>> {
         // Store peer on first request
@@ -149,7 +146,7 @@ Key points:
 
     fn list_resources<'a>(
         &'a self,
-        _params: Option<PaginatedRequestParam>,
+        _params: Option<PaginatedRequestParams>,
         ctx: RequestContext<RoleServer>,
     ) -> Pin<Box<dyn Future<Output = Result<ListResourcesResult, ErrorData>> + Send + 'a>> {
         // Store peer on first request

--- a/tests/transport_integration_test.rs
+++ b/tests/transport_integration_test.rs
@@ -780,10 +780,14 @@ async fn test_tool_list_notification() -> Result<()> {
     stdin.write_all(load_component_request.as_bytes()).await?;
     stdin.flush().await?;
 
-    // Read the tool list change notification first (this is what we're testing!)
+    // Read the tool list change notification first (this is what we're testing!).
+    // The server emits this notification only after `load_component` finishes,
+    // which compiles/instantiates the freshly-built wasm component. Under CI load
+    // that debug-build compile can take well over 30s, so use a generous timeout
+    // to avoid flaky failures.
     let mut notification_line = String::new();
     tokio::time::timeout(
-        Duration::from_secs(30),
+        Duration::from_secs(120),
         stdout.read_line(&mut notification_line),
     )
     .await
@@ -798,10 +802,10 @@ async fn test_tool_list_notification() -> Result<()> {
     assert_eq!(notification["method"], "notifications/tools/list_changed");
     println!("✓ Received tools/list_changed notification as expected");
 
-    // Read the actual load-component response
+    // Read the actual load-component response (same component-load cost applies)
     let mut load_response_line = String::new();
     tokio::time::timeout(
-        Duration::from_secs(30),
+        Duration::from_secs(120),
         stdout.read_line(&mut load_response_line),
     )
     .await

--- a/tests/transport_integration_test.rs
+++ b/tests/transport_integration_test.rs
@@ -14,7 +14,6 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
-use oci_wasm::WasmClient;
 use tempfile::TempDir;
 use test_log::test;
 use testcontainers::core::WaitFor;
@@ -353,27 +352,51 @@ async fn test_load_component_from_oci() -> Result<()> {
     // Give the registry a moment to fully start
     sleep(Duration::from_millis(500)).await;
 
-    // Read component bytes
-    let (config, layer) = oci_wasm::WasmConfig::from_component(component_path, None).await?;
-
     // Create OCI client and push the component
     let oci_client = oci_client::Client::new(oci_client::client::ClientConfig {
         protocol: oci_client::client::ClientProtocol::Http,
         ..Default::default()
     });
 
-    let wasm_client = WasmClient::new(oci_client);
     let reference = format!("{registry_url}/fetch_rs:latest");
     let oci_reference: oci_client::Reference = reference.parse()?;
 
-    // Push to registry
-    wasm_client
+    // Build the OCI-Wasm fixture directly. This test covers Wassette's OCI pull
+    // path, not oci-wasm's WIT metadata extraction.
+    let component_bytes = tokio::fs::read(component_path).await?;
+    let layer = oci_client::client::ImageLayer::new(
+        component_bytes,
+        oci_wasm::WASM_LAYER_MEDIA_TYPE.to_string(),
+        None,
+    );
+    let config_data = serde_json::to_vec(&serde_json::json!({
+        "created": "1970-01-01T00:00:00Z",
+        "author": null,
+        "architecture": oci_wasm::WASM_ARCHITECTURE,
+        "os": oci_wasm::COMPONENT_OS,
+        "layerDigests": [layer.sha256_digest()],
+        "component": {
+            "exports": ["fetch"],
+            "imports": [],
+            "target": null
+        }
+    }))?;
+    let config = oci_client::client::Config::new(
+        config_data,
+        oci_wasm::WASM_MANIFEST_CONFIG_MEDIA_TYPE.to_string(),
+        None,
+    );
+    let layers = [layer];
+    let mut manifest = oci_client::manifest::OciImageManifest::build(&layers, &config, None);
+    manifest.media_type = Some(oci_wasm::WASM_MANIFEST_MEDIA_TYPE.to_string());
+
+    oci_client
         .push(
             &oci_reference,
-            &oci_client::secrets::RegistryAuth::Anonymous,
-            layer,
+            &layers,
             config,
-            None,
+            &oci_client::secrets::RegistryAuth::Anonymous,
+            Some(manifest),
         )
         .await?;
 

--- a/tests/transport_integration_test.rs
+++ b/tests/transport_integration_test.rs
@@ -917,9 +917,7 @@ async fn test_http_transport() -> Result<()> {
     }
     let response = response.context("Failed to connect to HTTP server")?;
 
-    // The server should return some response (even if it's an error for GET requests)
-    // The important thing is that it's listening and responding
-    assert!(response.status().as_u16() >= 200);
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
 
     // Clean up
     child.kill().await.ok();

--- a/tests/transport_integration_test.rs
+++ b/tests/transport_integration_test.rs
@@ -443,7 +443,7 @@ async fn test_load_component_invalid_reference() -> Result<()> {
     Ok(())
 }
 #[test(tokio::test)]
-async fn test_mixed_transport_fails() -> Result<()> {
+async fn test_sse_transport_is_rejected() -> Result<()> {
     // Create a temporary directory for this test to avoid loading existing components
     let temp_dir = tempfile::tempdir()?;
     let component_dir_arg = format!("--component-dir={}", temp_dir.path().display());
@@ -453,52 +453,18 @@ async fn test_mixed_transport_fails() -> Result<()> {
         .context("Failed to get current directory")?
         .join("target/debug/wassette");
 
-    // Test mixing HTTP transport flags (--sse and --streamable-http)
-    // Note: --stdio is no longer part of serve command, it's now in the run command
-    let combinations = [["--sse", "--streamable-http"]];
+    let output = tokio::process::Command::new(&binary_path)
+        .args(["serve", &component_dir_arg, "--sse"])
+        .output()
+        .await
+        .context("Failed to run wassette with deprecated SSE transport")?;
 
-    for combo in combinations {
-        // Start the server with the current combination of transports (should fail)
-        let mut child = tokio::process::Command::new(&binary_path)
-            .args(["serve", &component_dir_arg])
-            .args(combo)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .context("Failed to start wassette with mixed transports")?;
-
-        let stderr = child.stderr.take().context("Failed to get stderr handle")?;
-        let mut stderr = BufReader::new(stderr);
-
-        // Give the server time to start
-        tokio::time::sleep(Duration::from_millis(1000)).await;
-
-        // Check if the process has exited
-        let status = child
-            .wait()
-            .await
-            .context("Failed to wait for wassette process")?;
-
-        assert!(
-            !status.success(),
-            "Process should have exited with error due to mixed transports"
-        );
-
-        // Read stderr output
-        let mut stderr_output = String::new();
-        let _ = stderr.read_line(&mut stderr_output).await;
-
-        let expected_error = format!(
-            "the argument '{}' cannot be used with '{}'",
-            combo[0], combo[1]
-        );
-
-        assert!(
-            stderr_output.contains(&expected_error),
-            "Expected error message about mixed transports, got: {stderr_output}"
-        );
-    }
+    assert!(!output.status.success());
+    let stderr_output = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr_output.contains("unexpected argument '--sse' found"),
+        "Expected SSE removal error, got: {stderr_output}"
+    );
 
     Ok(())
 }
@@ -885,27 +851,7 @@ async fn test_tool_list_notification() -> Result<()> {
 
 #[test(tokio::test)]
 async fn test_http_transport() -> Result<()> {
-    // Use a random available port to avoid conflicts
     let port = find_open_port().await?;
-
-    // We need to modify the source to support configurable bind address
-    // For now, let's test with the default port but check if it's available
-    let default_port = 9001u16;
-    let test_port = if TcpListener::bind(format!("127.0.0.1:{default_port}"))
-        .await
-        .is_ok()
-    {
-        default_port
-    } else {
-        port
-    };
-
-    // If we're not using the default port, skip this test for now
-    // since the server code uses a hardcoded bind address
-    if test_port != default_port {
-        println!("Skipping HTTP transport test: default port 9001 is not available");
-        return Ok(());
-    }
 
     // Create a temporary directory for this test to avoid loading existing components
     let temp_dir = tempfile::tempdir()?;
@@ -916,27 +862,37 @@ async fn test_http_transport() -> Result<()> {
         .context("Failed to get current directory")?
         .join("target/debug/wassette");
 
-    // Start the server with HTTP transport
+    let bind_address_arg = format!("--bind-address=127.0.0.1:{port}");
+
+    // Start the server with Streamable HTTP transport
     let mut child = tokio::process::Command::new(&binary_path)
-        .args(["serve", "--sse", &component_dir_arg])
+        .args([
+            "serve",
+            "--streamable-http",
+            &bind_address_arg,
+            &component_dir_arg,
+        ])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .context("Failed to start wassette with HTTP transport")?;
 
-    // Give the server time to start (less time needed with empty component dir)
-    tokio::time::sleep(Duration::from_millis(1000)).await;
-
     // Create HTTP client
     let client = reqwest::Client::new();
-    let base_url = format!("http://127.0.0.1:{test_port}");
+    let base_url = format!("http://127.0.0.1:{port}/health");
 
-    // Test that the server is responding
-    let response = tokio::time::timeout(Duration::from_secs(10), client.get(&base_url).send())
-        .await
-        .context("Timeout waiting for HTTP server response")?
-        .context("Failed to connect to HTTP server")?;
+    let mut response = None;
+    for _ in 0..40 {
+        match client.get(&base_url).send().await {
+            Ok(server_response) => {
+                response = Some(server_response);
+                break;
+            }
+            Err(_) => sleep(Duration::from_millis(250)).await,
+        }
+    }
+    let response = response.context("Failed to connect to HTTP server")?;
 
     // The server should return some response (even if it's an error for GET requests)
     // The important thing is that it's listening and responding


### PR DESCRIPTION
This PR repairs CI failures introduced by recent dependency updates, bumps the pinned compiler to Rust 1.97.1, and resolves the stricter Clippy diagnostics. It upgrades RMCP to address the high-severity DNS-rebinding advisory and replaces the deprecated SSE server transport with Streamable HTTP; terminal-agent integrations continue using stdio unchanged. It also pins CI security-tool installations and relaxes component-load test timeouts to improve reliability.