### PR TITLE
test: cover DNS rebinding protection

### DIFF
--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -34,7 +34,7 @@ ENV XDG_CONFIG_HOME=/home/wassette/.config
 USER wassette
 WORKDIR /home/wassette
 
-# Expose the default HTTP port (when using --http or --sse)
+# Expose the default Streamable HTTP port
 EXPOSE 9001
 
 # Default command: start Wassette with streamable-http transport

--- a/docs/deployment/docker-compose.example.yml
+++ b/docs/deployment/docker-compose.example.yml
@@ -43,11 +43,8 @@ services:
     # Default: Streamable HTTP transport (uses port 9001)
     # Uses the default CMD from Dockerfile - no need to specify
     
-    # Option 1: Override with stdio transport
+    # Override with stdio transport
     # command: ["wassette", "run"]
-    
-    # Option 2: Override with SSE transport
-    # command: ["wassette", "serve", "--sse"]
     
     # Security: Limit container resources
     deploy:

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -418,7 +418,7 @@ WORKDIR /home/wassette
 
 EXPOSE 9001
 
-CMD ["wassette", "run"]
+CMD ["wassette", "serve", "--streamable-http"]
 ```
 
 This approach is faster as it doesn't require compiling from source.

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -49,16 +49,6 @@ For use with MCP clients that expect stdio, override the default command:
 docker run -i --rm wassette:latest wassette run
 ```
 
-### Run with SSE Transport
-
-For SSE transport, override the default command:
-
-```bash
-docker run --rm -p 9001:9001 wassette:latest wassette serve --streamable-http
-```
-
-Then connect to `http://localhost:9001/sse` from your MCP client.
-
 ## Mounting Components
 
 To use custom WebAssembly components with Wassette in Docker, you need to mount the component directory:
@@ -199,9 +189,8 @@ services:
       - ./config.toml:/home/wassette/.config/wassette/config.toml:ro
     environment:
       - RUST_LOG=info
-    # Default is streamable-http, but you can override:
-    # command: ["wassette", "serve", "--sse"]
-    # command: ["wassette", "serve", "--stdio"]
+    # Default is Streamable HTTP, but you can override it with stdio:
+    # command: ["wassette", "run"]
     # Security: Run with limited resources
     deploy:
       resources:
@@ -339,7 +328,9 @@ docker run --rm -p 9001:9001 \
   wassette:latest
 ```
 
-**Note**: Health endpoints are only available with `--streamable-http` transport (the default for the Docker image). SSE transport (`--sse`) is designed solely for event streaming and does not expose standard HTTP endpoints like `/health`.
+**Note**: Health endpoints are only available with `--streamable-http`
+transport, which is the default for the Docker image. For stdio transport,
+monitor the process status instead.
 
 ### Persistent Component Storage
 
@@ -382,13 +373,13 @@ docker run -i --rm \
 
 ### Network Connectivity Issues
 
-When using HTTP/SSE transport, ensure the port is properly exposed:
+When using Streamable HTTP transport, ensure the port is properly exposed:
 
 ```bash
 # Check if the port is listening
 docker run -d --name wassette-test -p 9001:9001 wassette:latest wassette serve --streamable-http
 docker logs wassette-test
-curl http://localhost:9001/sse
+curl http://localhost:9001/health
 docker rm -f wassette-test
 ```
 
@@ -427,7 +418,7 @@ WORKDIR /home/wassette
 
 EXPOSE 9001
 
-CMD ["wassette", "serve", "--stdio"]
+CMD ["wassette", "run"]
 ```
 
 This approach is faster as it doesn't require compiling from source.

--- a/docs/deployment/operations.md
+++ b/docs/deployment/operations.md
@@ -73,10 +73,8 @@ RUST_LOG=mcp_server=debug,wassette=info wassette serve
 
 ### Log Output Location
 
-The log output location depends on the transport mode:
-
-- **SSE and StreamableHttp**: Logs go to stdout
-- **Stdio**: Logs go to stderr (to avoid interfering with the MCP protocol on stdout)
+Both Streamable HTTP and stdio write logs to stderr. For stdio, this avoids
+interfering with the MCP protocol on stdout.
 
 ### Sensitive Data Protection
 

--- a/docs/deployment/operations.md
+++ b/docs/deployment/operations.md
@@ -227,7 +227,8 @@ readinessProbe:
   periodSeconds: 10
 ```
 
-**Note**: Health endpoints are only available with `--streamable-http` transport. SSE transport (`--sse`) also uses HTTP but is designed solely for event streaming and does not provide a general HTTP request/response interface. For stdio or SSE transports, monitor the process status instead.
+**Note**: Health endpoints are only available with `--streamable-http`
+transport. For stdio transport, monitor the process status instead.
 
 ## Performance Tuning
 

--- a/docs/design/mcp-threat-model.md
+++ b/docs/design/mcp-threat-model.md
@@ -90,6 +90,10 @@ Wassette's permission model creates additional barriers against tool poisoning a
 
 The runtime also provides isolation between components. One component cannot poison another component's state, resources, or permissions. Each component execution occurs in a fresh instance with its own memory space and WASI context. This isolation prevents persistent compromise and limits the blast radius of successful attacks.
 
+When Wassette runs as an HTTP server, it exposes the MCP management plane, including tools that load components and grant permissions, on a local port. Binding to loopback does not prevent browser-based access: a malicious site can use DNS rebinding to make its hostname resolve to `127.0.0.1`, then send requests to the local server with the attacker's hostname in the `Host` header.
+
+Wassette mitigates this attack through rmcp's `StreamableHttpService`, which rejects HTTP requests whose `Host` header is not a trusted loopback value before MCP processing begins. Streamable HTTP at `/mcp` is now the only supported HTTP transport because the removed SSE transport did not provide this validation. Operators exposing Wassette beyond loopback should place it behind an authenticating reverse proxy.
+
 ## Attack Consequences
 
 The threat categories described above are root causes that can lead to various security consequences. Understanding these consequences helps in designing monitoring, incident response, and defense-in-depth strategies.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -185,7 +185,7 @@ This makes it safe to:
 
 Wassette provides comprehensive invocation logging for all tool calls. To access logs:
 
-1. **View real-time logs**: When running `wassette serve`, logs are output to stdout (SSE/HTTP) or stderr (stdio)
+1. **View real-time logs**: When running `wassette serve`, logs are output to stdout (Streamable HTTP) or stderr (stdio)
 2. **Increase verbosity**: Set `RUST_LOG=debug` or `RUST_LOG=trace` for more detailed logs
 3. **Filter logs**: Use grep to find specific invocations: `wassette serve 2>&1 | grep "Tool invocation"`
 4. **Parse structured data**: Extract timing and status information from key-value pairs in logs

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -185,7 +185,7 @@ This makes it safe to:
 
 Wassette provides comprehensive invocation logging for all tool calls. To access logs:
 
-1. **View real-time logs**: When running `wassette serve`, logs are output to stdout (Streamable HTTP) or stderr (stdio)
+1. **View real-time logs**: Both `wassette serve` and `wassette run` write logs to stderr
 2. **Increase verbosity**: Set `RUST_LOG=debug` or `RUST_LOG=trace` for more detailed logs
 3. **Filter logs**: Use grep to find specific invocations: `wassette serve 2>&1 | grep "Tool invocation"`
 4. **Parse structured data**: Extract timing and status information from key-value pairs in logs

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -687,7 +687,7 @@ The CLI commands complement the MCP server functionality. You can:
 {
   "name": "wassette",
   "command": "wassette",
-  "args": ["serve", "--stdio"]
+  "args": ["run"]
 }
 ```
 

--- a/docs/reference/configuration-files.md
+++ b/docs/reference/configuration-files.md
@@ -27,7 +27,7 @@ component_dir = "/path/to/components"
 # Default: $XDG_CONFIG_HOME/wassette/secrets (~/.config/wassette/secrets)
 secrets_dir = "/path/to/secrets"
 
-# Bind address for HTTP-based transports (SSE and StreamableHttp)
+# Bind address for Streamable HTTP
 # Default: 127.0.0.1:9001
 bind_address = "0.0.0.0:8080"
 
@@ -57,7 +57,7 @@ DATABASE_URL = "postgresql://localhost/mydb"
 
 - **Type**: String
 - **Default**: `127.0.0.1:9001`
-- **Description**: Bind address for HTTP-based transports (SSE and StreamableHttp). The address should be in the format `host:port`. Use `0.0.0.0` to bind to all network interfaces, or a specific IP address to bind to a particular interface. This setting is ignored when using stdio transport.
+- **Description**: Bind address for Streamable HTTP. The address should be in the format `host:port`. Use `0.0.0.0` to bind to all network interfaces, or a specific IP address to bind to a particular interface. This setting is ignored when using stdio transport.
 
 #### `environment_vars`
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -7,7 +7,7 @@ Pass environment variables to Wassette components using shell exports or config 
 Wassette supports the following environment variables for server configuration (following the [twelve-factor app](https://12factor.net/) methodology):
 
 ### PORT
-Sets the port number for HTTP-based transports (SSE and StreamableHttp) when `bind_address` is not specified via CLI or config file.
+Sets the port number for Streamable HTTP when `bind_address` is not specified via CLI or config file.
 
 ```bash
 PORT=8080 wassette serve --streamable-http

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,7 +60,7 @@ pub struct Config {
     #[serde(default)]
     pub environment_vars: HashMap<String, String>,
 
-    /// Bind address for HTTP-based transports (SSE and StreamableHttp)
+    /// Bind address for Streamable HTTP
     /// Configured via PORT and BIND_HOST environment variables or CLI/config file
     #[serde(default = "default_bind_address", rename = "bind_address")]
     pub bind_address: String,

--- a/tests/dns_rebinding_integration_test.rs
+++ b/tests/dns_rebinding_integration_test.rs
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Integration test reproducing the DNS-rebinding vulnerability
+//! (GHSA-m873-hg53-85r5).
+//!
+//! `wassette serve` exposes the MCP management plane over HTTP. Binding to
+//! loopback is not sufficient to prevent a malicious web page from reaching
+//! that endpoint through DNS rebinding, so the server must reject requests
+//! whose `Host` header is not a trusted loopback value before MCP dispatch.
+
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::process::{Child, Command};
+
+const FORGED_HOST: &str = "rebind.dev.pluto.security";
+
+async fn find_open_port() -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("failed to bind a random loopback port")?;
+    Ok(listener.local_addr()?.port())
+}
+
+async fn wait_until_listening(port: u16) -> Result<()> {
+    for _ in 0..100 {
+        if TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    bail!("wassette did not start listening on 127.0.0.1:{port}")
+}
+
+async fn post_initialize_status(port: u16, host_header: &str) -> Result<u16> {
+    let body = concat!(
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"#,
+        r#""protocolVersion":"2024-11-05","capabilities":{},"#,
+        r#""clientInfo":{"name":"dns-rebind-browser","version":"1"}}}"#,
+    );
+    let request = format!(
+        concat!(
+            "POST /mcp HTTP/1.1\r\n",
+            "Host: {host}\r\n",
+            "Accept: application/json, text/event-stream\r\n",
+            "Content-Type: application/json\r\n",
+            "Content-Length: {len}\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "{body}",
+        ),
+        host = host_header,
+        len = body.len(),
+        body = body,
+    );
+
+    let mut stream = TcpStream::connect(("127.0.0.1", port))
+        .await
+        .context("failed to connect to wassette /mcp")?;
+    stream.write_all(request.as_bytes()).await?;
+    stream.flush().await?;
+
+    // A successful initialize response may remain open as an event stream.
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 1024];
+    loop {
+        let read = tokio::time::timeout(Duration::from_secs(10), stream.read(&mut chunk))
+            .await
+            .context("timeout reading /mcp response")?
+            .context("failed to read /mcp response")?;
+        if read == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..read]);
+        if buf.windows(2).any(|window| window == b"\r\n") {
+            break;
+        }
+    }
+
+    let text = String::from_utf8_lossy(&buf);
+    let status_line = text.lines().next().context("empty response from /mcp")?;
+    status_line
+        .split_whitespace()
+        .nth(1)
+        .context("malformed HTTP status line")?
+        .parse::<u16>()
+        .context("could not parse HTTP status code")
+}
+
+struct ServerGuard(Child);
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.0.start_kill();
+    }
+}
+
+async fn spawn_server(port: u16, component_dir: &Path) -> Result<ServerGuard> {
+    let child = Command::new(env!("CARGO_BIN_EXE_wassette"))
+        .args([
+            "serve",
+            "--streamable-http",
+            "--bind-address",
+            &format!("127.0.0.1:{port}"),
+            &format!("--component-dir={}", component_dir.display()),
+        ])
+        .env("RUST_LOG", "error")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("failed to spawn `wassette serve --streamable-http`")?;
+    Ok(ServerGuard(child))
+}
+
+#[tokio::test]
+async fn dns_rebinding_foreign_host_is_rejected() -> Result<()> {
+    let port = find_open_port().await?;
+    let temp_dir = tempfile::tempdir()?;
+    let _server = spawn_server(port, temp_dir.path()).await?;
+    wait_until_listening(port).await?;
+
+    let loopback_host = format!("127.0.0.1:{port}");
+    let loopback_status = post_initialize_status(port, &loopback_host).await?;
+    assert_eq!(
+        loopback_status, 200,
+        "loopback Host `{loopback_host}` should be accepted (got {loopback_status})"
+    );
+
+    let forged_host = format!("{FORGED_HOST}:{port}");
+    let forged_status = post_initialize_status(port, &forged_host).await?;
+    assert_eq!(
+        forged_status, 403,
+        "forged Host `{forged_host}` must be rejected with 403 to prevent DNS \
+         rebinding (got {forged_status})"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This follow-up to #695 adds end-to-end coverage proving Streamable HTTP accepts loopback `Host` headers while rejecting forged foreign hosts with `403`. It also removes stale SSE deployment guidance and documents the DNS-rebinding threat and transport-level mitigation.