### PR TITLE
build: update Go and TinyGo toolchains

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -35,10 +35,14 @@ jobs:
       uses: bytecodealliance/actions/wasm-tools/setup@3b93676295fd6f7eaa7af2c2785539e052fa8349
     - name: Setup uv
       uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
+    - name: Setup Go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+      with:
+        go-version: 1.26.5
     - name: Setup TinyGo
       uses: acifani/setup-tinygo@db56321a62b9a67922bb9ac8f9d085e218807bb3
       with:
-        tinygo-version: 0.36.0
+        tinygo-version: 0.41.1
     - name: Cache Rust dependencies
       uses: ./.github/actions/rust-cache
     - name: Install gh-aw extension
@@ -51,6 +55,6 @@ jobs:
         cluster_name: wassette-dev
         wait: 300s
     - name: Verify tool installations
-      run: "echo \"=== Development Environment Setup Complete ===\"\necho \"\"\necho \"Rust toolchain:\"\nrustc --version\ncargo --version\necho \"\"\necho \"Nightly formatter:\"\ncargo +nightly fmt --version\necho \"\"\necho \"Build tools:\"\njust --version\nprotoc --version\nwasm-tools --version\necho \"\"\necho \"Language support:\"\nuv --version\ntinygo version\necho \"\"\necho \"WASM target installed:\"\nrustup target list --installed | grep wasm32-wasip2\necho \"\"\necho \"GitHub extensions:\"\ngh extension list\necho \"\"\necho \"Kubernetes cluster:\"\nkubectl cluster-info || true\nkubectl get nodes || true\necho \"\"\necho \"=== Ready for development! ===\"\necho \"You can now run:\"\necho \"  - just build     # Build the project\"\necho \"  - just test      # Run tests\"\necho \"  - just run       # Start MCP server\"\necho \"  - cargo clippy   # Run linter\"\necho \"  - kubectl get pods -A   # Check Kubernetes cluster\"\n"
+      run: "echo \"=== Development Environment Setup Complete ===\"\necho \"\"\necho \"Rust toolchain:\"\nrustc --version\ncargo --version\necho \"\"\necho \"Nightly formatter:\"\ncargo +nightly fmt --version\necho \"\"\necho \"Build tools:\"\njust --version\nprotoc --version\nwasm-tools --version\necho \"\"\necho \"Language support:\"\nuv --version\ngo version\ntinygo version\necho \"\"\necho \"WASM target installed:\"\nrustup target list --installed | grep wasm32-wasip2\necho \"\"\necho \"GitHub extensions:\"\ngh extension list\necho \"\"\necho \"Kubernetes cluster:\"\nkubectl cluster-info || true\nkubectl get nodes || true\necho \"\"\necho \"=== Ready for development! ===\"\necho \"You can now run:\"\necho \"  - just build     # Build the project\"\necho \"  - just test      # Run tests\"\necho \"  - just run       # Start MCP server\"\necho \"  - cargo clippy   # Run linter\"\necho \"  - kubectl get pods -A   # Check Kubernetes cluster\"\n"
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,7 +22,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  TINYGO_VERSION: 0.36.0
+  GO_VERSION: 1.26.5
+  TINYGO_VERSION: 0.41.1
 
 jobs:
   build:
@@ -31,6 +32,9 @@ jobs:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
     - uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
+    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        go-version: ${{ env.GO_VERSION }}
     - uses: acifani/setup-tinygo@db56321a62b9a67922bb9ac8f9d085e218807bb3 # v0.2.1
       with:
         tinygo-version: ${{ env.TINYGO_VERSION }}
@@ -144,4 +148,3 @@ jobs:
         if: steps.meta.outputs.latest == 'true'
         run: |
           cosign sign --yes ghcr.io/${{ github.repository_owner }}/${{ matrix.component.name }}@${{ steps.publish_latest.outputs.digest }}
-


### PR DESCRIPTION
This pull request updates the development and CI workflows to add Go language support and upgrade the TinyGo version. The changes ensure that Go is installed and available in both the main setup and example workflows, and that the correct versions are used consistently.

**Toolchain and Language Support Updates:**

* Added the `actions/setup-go` step to both `.github/workflows/copilot-setup-steps.yml` and `.github/workflows/examples.yml` to install Go version 1.26.5. [[1]](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dR38-R45) [[2]](diffhunk://#diff-8906835152921ef903f55779586f3a092362f65fca98df94d71801cf974ec95bL25-R26) [[3]](diffhunk://#diff-8906835152921ef903f55779586f3a092362f65fca98df94d71801cf974ec95bR35-R37)
* Upgraded the TinyGo version from 0.36.0 to 0.41.1 in both workflows for improved compatibility and features. [[1]](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dR38-R45) [[2]](diffhunk://#diff-8906835152921ef903f55779586f3a092362f65fca98df94d71801cf974ec95bL25-R26)

**Verification and Environment Output Improvements:**

* Updated the "Verify tool installations" step to include `go version` in the output, confirming Go is available in the environment.