### PR TITLE
fix: support prepared prereleases

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -33,10 +33,10 @@ jobs:
           # Extract version from branch name (release/v0.4.0 -> v0.4.0)
           VERSION="${BRANCH_NAME#release/}"
           
-          # Validate version format (vX.Y.Z)
-          if ! [[ $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          # Validate stable and prerelease version formats.
+          if ! [[ $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "Error: Invalid version format in branch name: $BRANCH_NAME"
-            echo "Expected format: release/vX.Y.Z (e.g., release/v0.4.0)"
+            echo "Expected release/vX.Y.Z or release/vX.Y.Z-suffix (e.g., release/v0.4.0-rc1)"
             exit 1
           fi
           

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'New version (without v prefix, e.g., 0.4.0)'
+        description: 'New version without v prefix (e.g., 0.4.0 or 0.4.0-rc1)'
         required: true
         type: string
 
@@ -25,8 +25,8 @@ jobs:
       - name: Validate version format
         run: |
           VERSION="${{ inputs.version }}"
-          if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Error: Version must be in format X.Y.Z (e.g., 0.4.0)"
+          if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Error: Version must use X.Y.Z or X.Y.Z-suffix format (e.g., 0.4.0 or 0.4.0-rc1)"
             exit 1
           fi
           echo "Valid version format: $VERSION"
@@ -62,10 +62,10 @@ jobs:
             1. Review and merge this PR to main
             2. After merge, the `auto-tag-release` workflow will automatically create and push tag `v${{ inputs.version }}`
             3. The release workflow will automatically trigger and create the GitHub release
-            4. The release workflow will update CHANGELOG.md and create a PR to merge changes back to main
-            5. The update-package-manifests workflow will automatically create a PR to update Homebrew and WinGet manifests
+            4. For stable releases, the release workflow will update CHANGELOG.md and create a PR to merge changes back to main
+            5. For stable releases, the update-package-manifests workflow will create a PR to update Homebrew and WinGet manifests
             
-            **Note:** The release branch will be kept for the release process and will be merged back to main after the release is complete.
+            **Note:** Versions with a suffix are published as prereleases and skip changelog, package manifest, example component, and versioned documentation updates.
           labels: |
             release
             automated

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ jobs:
           TAG_VERSION="${RELEASE_TAG#v}"
           TAG_BASE_VERSION="${TAG_VERSION%%-*}"
           PACKAGE_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)
-          if [ "$TAG_BASE_VERSION" != "$PACKAGE_VERSION" ]; then
-            echo "Error: tag $RELEASE_TAG has base version $TAG_BASE_VERSION, which does not match Cargo.toml version $PACKAGE_VERSION"
+          if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ] && [ "$TAG_BASE_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Error: tag $RELEASE_TAG does not match Cargo.toml version $PACKAGE_VERSION"
             exit 1
           fi
 

--- a/Justfile
+++ b/Justfile
@@ -40,6 +40,21 @@ install mode="debug":
     echo "You can add it by running:"
     echo '  export PATH="$HOME/.local/bin:$PATH"'
 
+# Create a stable or prerelease version bump PR through GitHub Actions.
+prepare-release version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    version={{ quote(version) }}
+    if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+        echo "error: version must use X.Y.Z or X.Y.Z-suffix format" >&2
+        exit 1
+    fi
+    gh workflow run prepare-release.yml \
+        --repo microsoft/wassette \
+        --ref main \
+        --field "version=$version"
+    echo "Dispatched Prepare Release for $version"
+
 # Check if wit-docs-inject is installed, if not install it
 ensure-wit-docs-inject:
     #!/usr/bin/env bash

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,22 +53,28 @@ in the repository Actions settings.
 
    1. Go to the [Actions tab](https://github.com/microsoft/wassette/actions/workflows/prepare-release.yml)
    1. Click "Run workflow"
-   1. Enter the new version number (without `v` prefix, e.g., `0.4.0`)
+   1. Enter the new version number without the `v` prefix (e.g., `0.4.0` or `0.4.0-rc1`)
    1. Click "Run workflow"
 
+   Alternatively, dispatch it with the project Justfile:
+
+   ```bash
+   just prepare-release 0.4.0-rc1
+   ```
+
    This will automatically:
-   - Create a release branch `release/vX.Y.Z`
+   - Create a release branch such as `release/vX.Y.Z` or `release/vX.Y.Z-rc1`
    - Update the version in `Cargo.toml`
    - Update `Cargo.lock`
    - Create a pull request to merge the release branch into main
 
 1. **Review and merge the version bump PR**: The workflow will create a pull request with the version changes. Review and merge this PR into the main branch.
 
-   **Important**: The release branch (`release/vX.Y.Z`) is preserved after merging and will be used during the release process.
+   **Important**: The release branch is preserved after merging and will be used during the release process.
 
 1. **Tag creation**: Once the version bump PR is merged, the `auto-tag-release.yml` workflow automatically:
-   - Extracts the version from the merged PR's branch name (`release/vX.Y.Z`)
-   - Creates an annotated tag `vX.Y.Z` on the merge commit
+   - Extracts the version from the merged PR's branch name
+   - Creates the corresponding annotated stable or prerelease tag on the merge commit
    - Pushes the tag to the repository
    - Dispatches the release workflow with the new tag
 
@@ -109,7 +115,11 @@ The release process supports dry run or test releases for validating the build a
 
 ### How to Create a Dry Run Release
 
-To create a dry run release, push a tag with a hyphen suffix (e.g., `-test1`, `-rc1`, `-alpha`, `-beta`):
+To prepare a versioned prerelease, run the Prepare Release workflow with a
+hyphen suffix such as `0.4.0-rc1`, then merge its version bump PR normally.
+
+To test the current package version without changing `Cargo.toml`, manually
+push a tag with a hyphen suffix (e.g., `-test1`, `-rc1`, `-alpha`, `-beta`):
 
 ```bash
 # Checkout the commit you want to test


### PR DESCRIPTION
This allows Prepare Release and Auto Tag Release to accept prerelease versions such as `0.5.0-rc1`, while retaining support for manually tagged dry runs against a stable package version. It also adds `just prepare-release <version>` and documents the two prerelease paths.