### PR TITLE
Update examples workflow to Node.js 24 actions

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -5,10 +5,12 @@ on:
     branches: [ "main" ]
     paths:
       - 'examples/**'
+      - '.github/workflows/examples.yml'
   pull_request:
     branches: [ "main" ]
     paths:
       - 'examples/**'
+      - '.github/workflows/examples.yml'
   workflow_dispatch:
     inputs:
       tag:
@@ -30,18 +32,18 @@ jobs:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         ref: ${{ startsWith(github.event.inputs.tag, 'v') && github.event.inputs.tag || github.ref }}
-    - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
+    - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
     - uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
     - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ env.GO_VERSION }}
-    - uses: acifani/setup-tinygo@db56321a62b9a67922bb9ac8f9d085e218807bb3 # v0.2.1
+    - uses: acifani/setup-tinygo@dd8a7075d951a7595b2ef2123ed0ab1af0c13e56 # v3.0.0
       with:
         tinygo-version: ${{ env.TINYGO_VERSION }}
-    - uses: bytecodealliance/actions/wasm-tools/setup@3b93676295fd6f7eaa7af2c2785539e052fa8349 # v1.1.1
+    - uses: bytecodealliance/actions/wasm-tools/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3
     - run: ./scripts/install-protobuf.sh
       shell: bash
-    - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+    - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
     - run: rustup target add wasm32-wasip2
 
     - name: Install wit-docs-inject
@@ -51,7 +53,7 @@ jobs:
       run: just build-examples
 
     - name: Upload wasm
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: examples
         path: bin
@@ -95,13 +97,13 @@ jobs:
             file: get-open-meteo-weather-js.wasm
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: examples
           path: bin
 
       - name: Log in to Container Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -110,6 +112,12 @@ jobs:
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
           cosign-release: 'v2.4.1'
+      - name: Install wkg
+        run: |
+          curl -L --proto '=https' --tlsv1.2 -sSf \
+            https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh |
+            bash
+          cargo binstall --no-confirm wkg@0.15.1
 
       - name: Determine tag
         id: meta
@@ -131,23 +139,43 @@ jobs:
           fi
       - name: Publish ${{ matrix.component.name }}
         id: publish_versioned
-        uses: bytecodealliance/wkg-github-action@10b3b04b9059ba46208cd7daf7d352af14bded0f # v5
-        with:
-          file: bin/${{ matrix.component.file }}
-          oci-reference-without-tag: ghcr.io/${{ github.repository_owner }}/${{ matrix.component.name }}
-          version: ${{ steps.meta.outputs.tag }}
+        env:
+          FILE: bin/${{ matrix.component.file }}
+          OCI_REFERENCE: ghcr.io/${{ github.repository_owner }}/${{ matrix.component.name }}
+          VERSION: ${{ steps.meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          output=$(wkg oci push "$OCI_REFERENCE:$VERSION" "$FILE" \
+            --annotation "org.opencontainers.image.description=" \
+            --annotation "org.opencontainers.image.source=" \
+            --annotation "org.opencontainers.image.url=" \
+            --annotation "org.opencontainers.image.version=$VERSION" \
+            --annotation "org.opencontainers.image.licenses=")
+          echo "$output"
+          digest=$(echo "$output" | grep -oP 'digest: \K.*')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
       - name: Sign container image ${{ matrix.component.name }}:${{ steps.meta.outputs.tag }}
         run: |
           cosign sign --yes ghcr.io/${{ github.repository_owner }}/${{ matrix.component.name }}@${{ steps.publish_versioned.outputs.digest }}
 
       - name: Publish ${{ matrix.component.name }} with tag ${{ steps.meta.outputs.release_tag || 'latest' }} (if specified)
         id: publish_latest
-        uses: bytecodealliance/wkg-github-action@10b3b04b9059ba46208cd7daf7d352af14bded0f # v5
         if: steps.meta.outputs.latest == 'true'
-        with:
-          file: bin/${{ matrix.component.file }}
-          oci-reference-without-tag: ghcr.io/${{ github.repository_owner }}/${{ matrix.component.name }}
-          version: ${{ steps.meta.outputs.release_tag || 'latest' }}
+        env:
+          FILE: bin/${{ matrix.component.file }}
+          OCI_REFERENCE: ghcr.io/${{ github.repository_owner }}/${{ matrix.component.name }}
+          VERSION: ${{ steps.meta.outputs.release_tag || 'latest' }}
+        run: |
+          set -euo pipefail
+          output=$(wkg oci push "$OCI_REFERENCE:$VERSION" "$FILE" \
+            --annotation "org.opencontainers.image.description=" \
+            --annotation "org.opencontainers.image.source=" \
+            --annotation "org.opencontainers.image.url=" \
+            --annotation "org.opencontainers.image.version=$VERSION" \
+            --annotation "org.opencontainers.image.licenses=")
+          echo "$output"
+          digest=$(echo "$output" | grep -oP 'digest: \K.*')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
       - name: Sign container image ${{ matrix.component.name }}:${{ steps.meta.outputs.release_tag || 'latest' }}
         if: steps.meta.outputs.latest == 'true'
         run: |


### PR DESCRIPTION
This updates the examples workflow to released Node.js 24-compatible actions. It replaces the `wkg` wrapper that still embeds `upload-artifact@v4` with equivalent pinned CLI publishing steps, removing the remaining deprecation warnings without changing artifact tags or signing.