### PR TITLE
chore(release): bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "wassette-mcp-server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wassette-mcp-server"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license.workspace = true
 


### PR DESCRIPTION
This pull request prepares the 0.5.0 release by updating the version in `Cargo.toml` and `Cargo.lock`. After merge, the release automation will create and publish tag `v0.5.0`. Versions with a suffix are prereleases and skip stable-release updates.