### PR TITLE
fix: remove duplicate and orphaned wasmparser entries from Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4703,17 +4703,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.254.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
-dependencies = [
- "bitflags",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.255.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e329ef4b5d46e73b91d3ac6924417cad55a8cbbf869c199283383427c3320b"
@@ -4723,17 +4712,6 @@ dependencies = [
  "indexmap 2.14.0",
  "semver",
  "serde",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.255.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e329ef4b5d46e73b91d3ac6924417cad55a8cbbf869c199283383427c3320b"
-dependencies = [
- "bitflags",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]


### PR DESCRIPTION
Cargo.lock contained two `[[package]]` entries for `wasmparser 0.255.0`. Both carry the same checksum, but they record different dependency sets: one includes `hashbrown` and `serde`, the other omits them. A lock file should hold exactly one entry per (name, version, source), so any cargo invocation rewrites the file and leaves the tree dirty.

It also carried a `wasmparser 0.254.0` entry that nothing referenced.

This commit applies the normalization cargo performs on its own: keep the 0.255.0 entry with the complete dependency set, drop the reduced duplicate, and drop the orphaned 0.254.0 entry. The retained checksum (e8e329ef4b5d46e73b91d3ac6924417cad55a8cbbf869c199283383427c3320b) matches crates.io. No dependency versions change.