### PR TITLE
chore: drop the stale paste advisory ignore

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,10 +1,6 @@
 # Cargo Audit Configuration
 [advisories]
-# Allow the paste crate warning as it's classified as unmaintained but still functional
-# We acknowledge the risk and plan to migrate to pastey in the future when possible
 ignore = [
-    "RUSTSEC-2024-0436",  # paste - no longer maintained
-
     # rustls-webpki 0.102.8 advisories: these are transitive dependencies pulled in by
     # wasmtime-wasi-http 36.x via rustls 0.22.4. The fixes require rustls-webpki >=0.103.x
     # which requires rustls 0.23.x. Wasmtime 36.x uses rustls 0.22.x internally, so these

--- a/.config/deny.toml
+++ b/.config/deny.toml
@@ -5,8 +5,6 @@
 [advisories]
 # Ignore list for known issues that are acceptable
 ignore = [
-    # paste crate is unmaintained but still widely used and safe
-    { id = "RUSTSEC-2024-0436", reason = "paste crate is unmaintained but still widely used and safe" },
     # fxhash is unmaintained but still widely used and safe; pulled in transitively by wasmtime
     { id = "RUSTSEC-2025-0057", reason = "fxhash is transitively required by wasmtime and still safe despite being unmaintained" },
     # rustls-webpki 0.102.8 is an internal dependency of wasmtime-wasi-http 36.x via rustls 0.22.4.


### PR DESCRIPTION
`paste` is no longer in the dependency tree — it was replaced by `pastey`, which the audit.toml comment anticipated ("plan to migrate to pastey in the future when possible"). The RUSTSEC-2024-0436 ignore therefore matches nothing.

cargo-deny reports this as dead config:

    warning[advisory-not-detected]: advisory was not encountered
      .config/deny.toml:9:13
      { id = "RUSTSEC-2024-0436", ... }
      no crate matched advisory criteria

Removes the entry from both .config/deny.toml and .cargo/audit.toml. The remaining ignores are still live and are left alone: RUSTSEC-2025-0057 (fxhash) and the four rustls-webpki advisories, which still apply because rustls-webpki 0.102.8 remains in the tree via wasmtime-wasi-http.

Verified: `cargo deny check advisories licenses bans sources` passes with no warnings, and `cargo audit` exits 0.