### PR TITLE
Upgrade Wasmtime to 47.0.3.

### DIFF
--- a/.config/deny.toml
+++ b/.config/deny.toml
@@ -4,18 +4,7 @@
 # Advisory database configuration
 [advisories]
 # Ignore list for known issues that are acceptable
-ignore = [
-    # fxhash is unmaintained but still widely used and safe; pulled in transitively by wasmtime
-    { id = "RUSTSEC-2025-0057", reason = "fxhash is transitively required by wasmtime and still safe despite being unmaintained" },
-    # rustls-webpki 0.102.8 is an internal dependency of wasmtime-wasi-http 36.x via rustls 0.22.4.
-    # The fixes require rustls-webpki >=0.103.x which requires rustls 0.23.x.
-    # Wasmtime 36.x uses rustls 0.22.x internally; this will be resolved when wasmtime is upgraded
-    # to a version that uses rustls 0.23+.
-    { id = "RUSTSEC-2026-0049", reason = "rustls-webpki 0.102.8 is an internal dep of wasmtime-wasi-http 36.x; fix requires rustls 0.23+ which wasmtime 36.x does not use" },
-    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.102.8 is an internal dep of wasmtime-wasi-http 36.x; fix requires rustls 0.23+ which wasmtime 36.x does not use" },
-    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.102.8 is an internal dep of wasmtime-wasi-http 36.x; fix requires rustls 0.23+ which wasmtime 36.x does not use" },
-    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.102.8 is an internal dep of wasmtime-wasi-http 36.x; fix requires rustls 0.23+ which wasmtime 36.x does not use" },
-]
+ignore = []
 
 # License checking configuration
 [licenses]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.25.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
  "gimli",
 ]
@@ -152,7 +152,7 @@ dependencies = [
  "libc",
  "portable-atomic",
  "rustc-hash",
- "rustix 1.1.4",
+ "rustix",
  "tokio",
  "tokio-stream",
  "xattr",
@@ -369,7 +369,7 @@ dependencies = [
  "num",
  "pin-project-lite",
  "rand 0.9.5",
- "rustls 0.23.43",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -450,12 +450,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,80 +457,44 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cap-fs-ext"
-version = "3.4.5"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "io-lifetimes",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "cap-net-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
-dependencies = [
- "cap-primitives",
- "cap-std",
- "rustix 1.1.4",
- "smallvec",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "cap-primitives"
-version = "3.4.5"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 3.0.1",
  "ipnet",
  "maybe-owned",
- "rustix 1.1.4",
+ "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
  "winx",
-]
-
-[[package]]
-name = "cap-rand"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
-dependencies = [
- "ambient-authority",
- "rand 0.8.7",
 ]
 
 [[package]]
 name = "cap-std"
-version = "3.4.5"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
 dependencies = [
  "cap-primitives",
  "io-extras",
- "io-lifetimes",
- "rustix 1.1.4",
-]
-
-[[package]]
-name = "cap-time-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
-dependencies = [
- "ambient-authority",
- "cap-primitives",
- "iana-time-zone",
- "once_cell",
- "rustix 1.1.4",
- "winx",
+ "io-lifetimes 3.0.1",
+ "rustix",
 ]
 
 [[package]]
@@ -738,9 +696,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
@@ -765,46 +723,48 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.13"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f8e1303ae2128891cb59691a74de4547dd208bc8511a2f287cca2b93bb3c728"
+checksum = "d552bd33b7a56dc70aeb1e1c960e51a218fa0db50f23873b500a310379450b2d"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.13"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b2740a5936332028d9a1e8f29a199de2fd386e426d44da5fea70cf8e3f8e75"
+checksum = "078e80e4c222279e3330f6aa1a256ca77ddf156d4453166a9f09defedc4594dd"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.13"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fd128d3629fb105e433bda09744c5a2959cd1da04617a455c4cc17dff1ebef"
+checksum = "820ce15d4ad3562d613c31a67b6d0434d403e7091a68d1349903842f7d31737e"
 dependencies = [
  "cranelift-entity",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.13"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a88f6d5a6cf6fcbc6386415d48948094721dfa4585d6615938b11ca938f20a"
+checksum = "61bca563d4b86d285928d9e27f97f27039bb33a0fc524fa130d7d0c106bf8ab3"
 dependencies = [
  "serde",
  "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.13"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4a357d030bdd586d8fe3da56b394f7f6b6ded506e59f945e7b32b1e126b71"
+checksum = "709f4b7c0fb57d952658d5b5c07fbdc4149acd7b7f0de9678ae754b9c981949a"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -816,22 +776,26 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
+ "libm",
  "log",
+ "postcard",
  "pulley-interpreter",
  "regalloc2",
  "rustc-hash",
  "serde",
+ "serde_derive",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.13"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4121e36a8757dea6fb237435ee5095eba25bc13ecc2eaee57eb9bffd4b27784f"
+checksum = "903dc8915af62aad1d9d0f39a5968d33fa80b9aa899ed6f56e47f40ca4512e1e"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -842,37 +806,39 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.13"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5173265fc30b9e42205cf06dfca9a272ee949667ce4115d975ed2c08d466e2f8"
+checksum = "0522d74c227e49f3fd49ab055311486ae4f09083262b66705bed676952491469"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.13"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6ca8a393e66dc13f915c6f456bdcf496d78fac4995792f7022b7806352d7a4"
+checksum = "66560ea1c5cef72e170b18e46d263dba2d3169c9d39e8cafdab2173c6362cc1a"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.13"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e609d9ba416bc26d774f343295a1d411515248a6a6d83d5f7492a0dd919569fa"
+checksum = "b62ef5b17cc814d27e96b66a5b46da0e4ce2b8ac55a6d478048bb99d04b05526"
 dependencies = [
  "cranelift-bitset",
  "serde",
  "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.13"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a3a277b1a0aff1123f6bae61c080a4bcb6df964829ed427f98e18dff14257f"
+checksum = "a87e0aaa39dbf70693b348a221e45904111704ee8f9fef140498471005f9842d"
 dependencies = [
  "cranelift-codegen",
+ "hashbrown 0.17.1",
  "log",
  "smallvec",
  "target-lexicon",
@@ -880,15 +846,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.13"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be53dd9b3a4cbeb9ced45c4a543ea8417ccfb334c3ba1cbb2233f4b25fb2531f"
+checksum = "cf79003ebfa1eed5e87f3b84446ad5236f540268289960e14f387dc9b28e40b7"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.13"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca62ab1d9f48cad97da5843b913ccf96c3dfde935af5d750cb5a6d367ccfb262"
+checksum = "05bf4f235743c81e67ee4db617c5a4a0b65d58d3f0cfc575ee0f1a4e0cd58273"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -897,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.13"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13b72860f54a2a19d3756bd47575fd8bddeafd6e5bbbf16372cdfebc482628a"
+checksum = "f6977c2a71ab1e0d1e62f966b411a498aa04c4dce47d93d52f8a360a06058922"
 
 [[package]]
 name = "crc32fast"
@@ -1244,27 +1210,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
-
-[[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix 1.1.4",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "ferroid"
@@ -1286,7 +1235,7 @@ dependencies = [
  "atomic",
  "pear",
  "serde",
- "toml",
+ "toml 0.8.23",
  "uncased",
  "version_check",
 ]
@@ -1298,16 +1247,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1330,8 +1279,8 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
- "io-lifetimes",
- "rustix 1.1.4",
+ "io-lifetimes 2.0.4",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -1430,24 +1379,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "fxprof-processed-profile"
-version = "0.6.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
+checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
 dependencies = [
  "bitflags",
  "debugid",
- "fxhash",
+ "rustc-hash",
  "serde",
+ "serde_derive",
  "serde_json",
 ]
 
@@ -1513,11 +1454,12 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.32.3"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
- "fallible-iterator",
+ "fnv",
+ "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "stable_deref_trait",
 ]
@@ -1561,13 +1503,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
- "serde",
-]
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
@@ -1575,7 +1513,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
  "serde",
  "serde_core",
 ]
@@ -1715,9 +1653,9 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.43",
+ "rustls",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -1944,12 +1882,12 @@ checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "io-extras"
-version = "0.18.4"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
- "io-lifetimes",
- "windows-sys 0.59.0",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1957,6 +1895,12 @@ name = "io-lifetimes"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
 
 [[package]]
 name = "ipnet"
@@ -2171,12 +2115,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2210,12 +2148,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "matchers"
@@ -2265,7 +2200,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
@@ -2400,12 +2335,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.37.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "memchr",
 ]
@@ -2603,6 +2538,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,7 +2664,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.5",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2761,21 +2706,21 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2662666315cb90dfb4d99a652ee053d4d8598f71c474209e84da031ca56ae5a4"
+checksum = "bc5c8c21ea032e4efbdf2d067dc45171779dbe0c8ecf20ef4a57efa7474f2b0a"
 dependencies = [
  "cranelift-bitset",
  "log",
  "pulley-macros",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9a7d9ed2618f94b6d054aba3eb2768c9b489fe16b4ef8847fbc6ed41b707bb"
+checksum = "9f10925455d5dde962e3604eade797ba5488644c8ee14a44191e2f2b58980574"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2800,7 +2745,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.43",
+ "rustls",
  "socket2",
  "thiserror 2.0.19",
  "tokio",
@@ -2822,7 +2767,7 @@ dependencies = [
  "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.19",
@@ -2868,22 +2813,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -2896,16 +2830,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3036,15 +2960,16 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.12.2"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5216b1837de2149f8bc8e6d5f88a9326b63b8c836ed58ce4a0a29ec736a59734"
+checksum = "757712e8e61590d6d4f5d563483755538b5aa13467837a3b41cd9832509a7f85"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "log",
  "rustc-hash",
+ "serde",
  "smallvec",
 ]
 
@@ -3101,7 +3026,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -3109,7 +3034,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3211,19 +3136,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3231,7 +3143,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -3242,21 +3154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix 1.1.4",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
+ "rustix",
 ]
 
 [[package]]
@@ -3270,7 +3168,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3308,10 +3206,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.43",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -3323,17 +3221,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -3549,6 +3436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -3841,22 +3737,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-interface"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
-dependencies = [
- "bitflags",
- "cap-fs-ext",
- "cap-std",
- "fd-lock",
- "io-lifetimes",
- "rustix 0.38.44",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,7 +3760,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -4090,22 +3970,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.43",
+ "rustls",
  "tokio",
 ]
 
@@ -4152,9 +4021,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4167,6 +4051,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4174,10 +4067,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.14.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -4185,6 +4087,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -4445,7 +4353,7 @@ dependencies = [
  "base64",
  "log",
  "percent-encoding",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
@@ -4622,13 +4530,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.236.1"
+name = "wasm-compose"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724fccfd4f3c24b7e589d333fc0429c68042897a7e8a5f8694f31792471841e7"
+checksum = "d59b710751a35d54732a63851cdfacbfb2266b7160ce174faf269d3f4e84e31b"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "log",
+ "petgraph",
+ "smallvec",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
+ "wat",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.236.1",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -4678,12 +4603,12 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.236.1"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "semver",
  "serde",
@@ -4716,33 +4641,31 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.236.1"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df225df06a6df15b46e3f73ca066ff92c2e023670969f7d50ce7d5e695abbb1"
+checksum = "7142797de29b35ab8dbf15c00f55fda75d409da4c423a8ab8bd6b667a785824b"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.236.1",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d881c5dcff5f230368d84fcf110ca25fe47badc694e7d559c3891492159916"
+checksum = "c80ca6098e0d4d06886d91d7f2cc3cb6623eb583c4c0ab3c89cbfb6098c8586c"
 dependencies = [
  "addr2line",
- "anyhow",
  "async-trait",
  "bitflags",
  "bumpalo",
  "cc",
  "cfg-if",
  "encoding_rs",
+ "futures",
  "fxprof-processed-profile",
  "gimli",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
  "ittapi",
  "libc",
  "log",
@@ -4753,44 +4676,46 @@ dependencies = [
  "postcard",
  "pulley-interpreter",
  "rayon",
- "rustix 1.1.4",
+ "rustix",
  "semver",
  "serde",
  "serde_derive",
  "serde_json",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.236.1",
- "wasmparser 0.236.1",
+ "tempfile",
+ "wasm-compose",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
  "wasmtime-environ",
- "wasmtime-internal-asm-macros",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
  "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-fiber",
  "wasmtime-internal-jit-debug",
  "wasmtime-internal-jit-icache-coherence",
- "wasmtime-internal-math",
- "wasmtime-internal-slab",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
  "wat",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b25534a3ff9dd844701c2bc997f76cb1f97bf2af0546a7066ae96f49c2e068"
+checksum = "134f9d136d29c76f6c1b4c9b468e97a2efc38c7d49fd188e39b64870b2fea701"
 dependencies = [
  "anyhow",
  "cpp_demangle",
+ "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
  "gimli",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "log",
  "object",
@@ -4799,48 +4724,41 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.236.1",
- "wasmparser 0.236.1",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
-]
-
-[[package]]
-name = "wasmtime-internal-asm-macros"
-version = "36.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d02832d760351fb3a1aa99eb8f7b95596c0f4e4e52df1547fcdb295ea5c780c"
-dependencies = [
- "cfg-if",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "651f8a16b51cde3ee8bd5b775bcedc24b66040d7dca1f13ad855b10c660e1d01"
+checksum = "65db2eb1bfc5371a3b4107dbf539d0b93d05016fc29625b1648146b47db02071"
 dependencies = [
- "anyhow",
  "base64",
  "directories-next",
  "log",
  "postcard",
- "rustix 1.1.4",
+ "rustix",
  "serde",
  "serde_derive",
  "sha2 0.10.9",
- "toml",
- "windows-sys 0.60.2",
+ "toml 0.9.12+spec-1.1.0",
+ "wasmtime-environ",
+ "windows-sys 0.61.2",
  "zstd",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ed6dbe24607573f7bcc59222f3bc2e7f7d31609466055c67b9484045a374a"
+checksum = "2bf7b91fed3fc34781d57f9c6654ea2513bf0a99f7b0b0523c00de1e6efebe1c"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4848,22 +4766,33 @@ dependencies = [
  "syn 2.0.119",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.236.1",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21aadbf677ee3503ef2580ce3c6955508e90a2810e961739b30f79585af254c"
+checksum = "fc8a678149885cae00289f806fbe74c7863084cf74cace0b8dc73602279400e1"
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "47.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0092c4b9d070ac5e278b6d0db10f5e71214190f0347ca57502b4692f796321"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "libm",
+ "serde",
+]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65821bab751956cddfc6ee957beb13a0e2a6cf682050d75dfb7a0228db2ed499"
+checksum = "6851ebc9e03cab23d9821d2b2505d380bdfe38f35ccec945247b05274d85c98b"
 dependencies = [
- "anyhow",
  "cfg-if",
  "cranelift-codegen",
  "cranelift-control",
@@ -4878,85 +4807,70 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.19",
- "wasmparser 0.236.1",
+ "wasmparser 0.252.0",
  "wasmtime-environ",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18cf73e5e8d28a2b30d86454430c7dea3b593598dcbbc0ebb927ca2716222d41"
+checksum = "9b26da6d5f60d4c438da70bba3553fe810a840533a64156be287dca2081c6991"
 dependencies = [
- "anyhow",
  "cc",
  "cfg-if",
  "libc",
- "rustix 1.1.4",
- "wasmtime-internal-asm-macros",
+ "rustix",
+ "wasmtime-environ",
  "wasmtime-internal-versioned-export-macros",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4279dc3147ddaa21e5b3d2c0eaff117881c4f937747bdd2379eb361665843bd3"
+checksum = "ed621ba25d7bf78b7edd7b4749abbb27c2e5cdba836c9504a424ee74b6c23149"
 dependencies = [
  "cc",
  "object",
- "rustix 1.1.4",
+ "rustix",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb677944201839c0be19b39b0f19dcd663efbcbc05a09c73f26fec7bdf0331"
+checksum = "5684ba160951baad06a725696f3c590e2fb0e8067c2aebee27bf7f9259058e85"
 dependencies = [
- "anyhow",
  "cfg-if",
  "libc",
- "windows-sys 0.60.2",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "wasmtime-internal-math"
-version = "36.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9a153e184878df396a11f8912444531c2e4d0c7a1d9e9a52b30d9853d89cb9"
-dependencies = [
- "libm",
-]
-
-[[package]]
-name = "wasmtime-internal-slab"
-version = "36.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b771494bead25e1f0c4c89a9476dd0b65eacca314ed82125f1e197fbc3f0396b"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90199caed6925420434a923861d8ad813689ca8533d2c679f805d12e35b40a4b"
+checksum = "112eead527bffa8ff0646a11fb4339a9d52ddd1da2b9a6fce4aff84c815dd94f"
 dependencies = [
- "anyhow",
  "cfg-if",
  "cranelift-codegen",
  "log",
  "object",
+ "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae71687aa834f9cc9eb5b0f97c85184d7dc70b84d32fd8927af0887998a1ba35"
+checksum = "153592e0bed824fc13c6696203fa1bd7bd20eb355316475e39a55f081ef80eca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4964,56 +4878,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-winch"
-version = "36.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ba45c0d766dd56257d97702d3284b6f69efdd4c53ca981a0754cc0a139df0"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
- "gimli",
- "object",
- "target-lexicon",
- "wasmparser 0.236.1",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a64d5112c06f9d54b41e61f0b757d3a5a52361bf359f01131cc7cb8551ac73"
+checksum = "c456ad6e81e0f46abfeca43687d18ea15e289c395b262ea6e0023e2682e088be"
 dependencies = [
  "anyhow",
  "bitflags",
  "heck",
  "indexmap 2.14.0",
- "wit-parser 0.236.1",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e4772f39340104c70837d421c71c50364c185936f07eaee19e46cb0754c9e1"
+checksum = "4c1cf60cd6a565213af7074b4aad7bb5e110e3c6c6aae54425aa0500a0e15e86"
 dependencies = [
- "anyhow",
  "async-trait",
  "bitflags",
  "bytes",
  "cap-fs-ext",
- "cap-net-ext",
- "cap-rand",
  "cap-std",
- "cap-time-ext",
- "fs-set-times",
+ "cfg-if",
  "futures",
- "io-extras",
- "io-lifetimes",
- "rustix 1.1.4",
- "system-interface",
+ "io-lifetimes 3.0.1",
+ "rand 0.10.2",
+ "rustix",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5021,26 +4913,24 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi-io",
  "wiggle",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d07a9f8639e2fa11a88882b09bb9f1782a915cc988152214e161c013df87aed"
+checksum = "3d596d7fee965a6199b2a71ee18ffdfc4837a64e4be272504d138cafd6918380"
 dependencies = [
- "anyhow",
  "wasmtime",
 ]
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d57c7686d03453f28aedf1770c134b6ed403addaca520745ab1eb3b291f8b7d"
+checksum = "a499879061ee9f724342d5f5009754b723ae53c7932161ee063a9fe19395e915"
 dependencies = [
- "anyhow",
  "async-trait",
  "bytes",
  "futures",
@@ -5048,26 +4938,26 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "rustls 0.22.4",
+ "rustls",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-io",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1267c55a52d9ce27da6ff522ddb5b847e811cf477b0ef4c7c1155dd544c25ac"
+checksum = "7fb08e1d7755aaa467ce14080b7b01e33c914a920f6000696f1e42e40ea6387e"
 dependencies = [
- "anyhow",
  "async-trait",
  "bytes",
  "futures",
+ "tracing",
  "wasmtime",
 ]
 
@@ -5088,6 +4978,7 @@ dependencies = [
  "policy",
  "proptest",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5134,7 +5025,7 @@ dependencies = [
  "rcgen",
  "reqwest",
  "rmcp",
- "rustls 0.23.43",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5144,7 +5035,7 @@ dependencies = [
  "test-log",
  "testcontainers",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-test",
  "tracing",
  "tracing-subscriber",
@@ -5214,15 +5105,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
@@ -5232,38 +5114,37 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3185c97adf4d5f4c0d2abfea7f0bdeb21b486970acd2cf19c7a7fd95308f1764"
+checksum = "89091642df051b84a7e00bdff75e985e507f2298384e477cc9310b0ddd79f004"
 dependencies = [
- "anyhow",
- "async-trait",
  "bitflags",
  "thiserror 2.0.19",
  "tracing",
  "wasmtime",
+ "wasmtime-environ",
  "wiggle-macro",
 ]
 
 [[package]]
 name = "wiggle-generate"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a019367ecff91d714d8f6cba589c36d7b16195eff0598236f9ce5aaf8b811d"
+checksum = "12247f46f31bb5e7593947f9bba07317d0c1978e0d02250b979dd08f56f46e9f"
 dependencies = [
- "anyhow",
  "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+ "wasmtime-environ",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-macro"
-version = "36.0.13"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2f5a33059321aee91888c331b45de1d6e9f9d0f89ab88398ef1fda2d3ee1fb"
+checksum = "e556a0880c9506fdcc662b1e226c7ced692f4977fed5b1ed40a3f3f0a48356f2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5301,26 +5182,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "36.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ea9625459ce35d6a4188cf0f07c9095cbb0e5afd86f711d63955bfc4216e64"
-dependencies = [
- "anyhow",
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.19",
- "wasmparser 0.236.1",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-math",
-]
 
 [[package]]
 name = "windows-core"
@@ -5567,6 +5428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
 name = "winx"
 version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5603,11 +5470,12 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.236.1"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e4833a20cd6e85d6abfea0e63a399472d6f88c6262957c17f546879a80ba15"
+checksum = "4266bea110371c620ccf3201c5023676046bc4556e5c7cfb5d500bda5ebc162d"
 dependencies = [
  "anyhow",
+ "hashbrown 0.17.1",
  "id-arena",
  "indexmap 2.14.0",
  "log",
@@ -5615,8 +5483,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "unicode-xid",
- "wasmparser 0.236.1",
+ "unicode-ident",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -5681,7 +5549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ oci-wasm = { version = "0.6", default-features = false, features = ["rustls-tls"
 policy = { path = "crates/policy" }
 reqwest = { version = "0.13", features = ["stream"] }
 rmcp = "1.4.0"
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
 serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.9"
@@ -33,10 +34,10 @@ tokio-util = "0.7.18"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-test = "0.2"
-wasmtime = "36.0.13"
-wasmtime-wasi = "36.0.13"
-wasmtime-wasi-http = "36.0.13"
-wasmtime-wasi-config = "36.0.13"
+wasmtime = "47.0.3"
+wasmtime-wasi = "47.0.3"
+wasmtime-wasi-http = "47.0.3"
+wasmtime-wasi-config = "47.0.3"
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ oci-wasm = { version = "0.6", default-features = false, features = ["rustls-tls"
 policy = { path = "crates/policy" }
 reqwest = { version = "0.13", features = ["stream"] }
 rmcp = "1.4.0"
-rustls = { version = "0.23", features = ["aws-lc-rs"] }
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
 serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/crates/component2json/src/lib.rs
+++ b/crates/component2json/src/lib.rs
@@ -136,7 +136,7 @@ pub fn component_exports_to_tools(
             export_name,
             None,
             None,
-            &export_item,
+            &export_item.ty,
             engine,
             &mut tools,
             output,
@@ -228,7 +228,7 @@ pub fn component_exports_to_tools_with_docs(
             export_name,
             None,
             None,
-            &export_item,
+            &export_item.ty,
             &mut tools,
             &context,
         );
@@ -325,6 +325,21 @@ fn type_to_json_schema(t: &Type) -> Value {
             json!({
                 "type": "array",
                 "items": elem_schema
+            })
+        }
+        Type::Map(map_handle) => {
+            let key_schema = type_to_json_schema(&map_handle.key());
+            let value_schema = type_to_json_schema(&map_handle.value());
+            json!({
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "key": key_schema,
+                        "value": value_schema
+                    },
+                    "required": ["key", "value"]
+                }
             })
         }
 
@@ -624,7 +639,7 @@ fn gather_exported_functions_with_metadata_internal(
                     export_name,
                     previous_name.clone(),
                     package_name.clone(),
-                    &export_item,
+                    &export_item.ty,
                     results,
                     context,
                 );
@@ -637,7 +652,7 @@ fn gather_exported_functions_with_metadata_internal(
                     export_name,
                     previous_name.clone(),
                     package_name.clone(),
-                    &export_item,
+                    &export_item.ty,
                     results,
                     context,
                 );
@@ -671,6 +686,17 @@ fn val_to_json(val: &Val) -> Value {
         Val::String(s) => Value::String(s.clone()),
 
         Val::List(list) => Value::Array(list.iter().map(val_to_json).collect()),
+        Val::Map(entries) => Value::Array(
+            entries
+                .iter()
+                .map(|(key, value)| {
+                    json!({
+                        "key": val_to_json(key),
+                        "value": val_to_json(value)
+                    })
+                })
+                .collect(),
+        ),
         Val::Record(fields) => {
             let mut map = Map::new();
             for (k, v) in fields {
@@ -830,6 +856,28 @@ fn json_to_val(value: &Value, ty: &Type) -> Result<Val, ValError> {
             }
             _ => Err(ValError::ShapeError("list", format!("{value:?}"))),
         },
+        Type::Map(map_handle) => match value {
+            Value::Array(entries) => {
+                let mut pairs = Vec::with_capacity(entries.len());
+                for entry in entries {
+                    let entry = entry
+                        .as_object()
+                        .ok_or_else(|| ValError::ShapeError("map entry", format!("{entry:?}")))?;
+                    let key = entry.get("key").ok_or_else(|| {
+                        ValError::ShapeError("map entry", "missing key".to_string())
+                    })?;
+                    let value = entry.get("value").ok_or_else(|| {
+                        ValError::ShapeError("map entry", "missing value".to_string())
+                    })?;
+                    pairs.push((
+                        json_to_val(key, &map_handle.key())?,
+                        json_to_val(value, &map_handle.value())?,
+                    ));
+                }
+                Ok(Val::Map(pairs))
+            }
+            _ => Err(ValError::ShapeError("map", format!("{value:?}"))),
+        },
         Type::Record(r) => match value {
             Value::Object(obj) => {
                 let mut fields = Vec::<(String, Val)>::new();
@@ -967,6 +1015,7 @@ fn default_val_for_type(ty: &Type) -> Val {
         Type::Char => Val::Char('\0'),
         Type::String => Val::String("".to_string()),
         Type::List(_) => Val::List(Vec::new()),
+        Type::Map(_) => Val::Map(Vec::new()),
 
         Type::Record(r) => {
             let fields = r
@@ -1246,7 +1295,6 @@ mod tests {
     fn test_root_component_exports() {
         let mut config = wasmtime::Config::new();
         config.wasm_component_model(true);
-        config.async_support(true);
         let engine = Engine::new(&config).unwrap();
         let component = Component::from_file(&engine, "testdata/filesystem.wasm").unwrap();
         let schema = component_exports_to_json_schema(&component, &engine, true);
@@ -1748,6 +1796,7 @@ mod tests {
     fn test_roundtrip() {
         let mut config = wasmtime::Config::new();
         config.wasm_component_model(true);
+        config.wasm_component_model_map(true);
         let engine = Engine::new(&config).unwrap();
 
         // A component that directly exports the types we want to test.
@@ -1774,6 +1823,8 @@ mod tests {
           (export (;13;) "f" (type (eq 12)))
           (type (;14;) (list 5))
           (export (;15;) "l" (type (eq 14)))
+          (type (;16;) (map string u32))
+          (export (;17;) "m" (type (eq 16)))
         )
       )
       (export (;0;) "wassette:test/types@0.1.0" (instance (type 0)))
@@ -1802,6 +1853,8 @@ mod tests {
               (export (;13;) "f" (type (eq 12)))
               (type (;14;) (list 5))
               (export (;15;) "l" (type (eq 14)))
+              (type (;16;) (map string u32))
+              (export (;17;) "m" (type (eq 16)))
             )
           )
           (import "wassette:test/types@0.1.0" (instance (;0;) (type 0)))
@@ -1838,7 +1891,7 @@ mod tests {
         let component_type = component.component_type();
 
         let types_component_export = component_type.get_export(&engine, "types").unwrap();
-        let types_component = match types_component_export {
+        let types_component = match types_component_export.ty {
             wasmtime::component::types::ComponentItem::Component(c) => c,
             _ => panic!("Expected 'types' to be a component export"),
         };
@@ -1846,16 +1899,16 @@ mod tests {
         let types_instance_export = types_component
             .get_export(&engine, "wassette:test/types@0.1.0")
             .unwrap();
-        let types_instance = match types_instance_export {
+        let types_instance = match types_instance_export.ty {
             wasmtime::component::types::ComponentItem::ComponentInstance(i) => i,
             _ => panic!("Expected an instance export"),
         };
 
-        let get_exported_type = |name: &str| match types_instance.get_export(&engine, name).unwrap()
-        {
-            wasmtime::component::types::ComponentItem::Type(ty) => ty,
-            _ => panic!("Expected a type export for '{name}'"),
-        };
+        let get_exported_type =
+            |name: &str| match types_instance.get_export(&engine, name).unwrap().ty {
+                wasmtime::component::types::ComponentItem::Type(ty) => ty,
+                _ => panic!("Expected a type export for '{name}'"),
+            };
 
         let record_type = get_exported_type("r");
         let original_record = Val::Record(vec![
@@ -1918,6 +1971,29 @@ mod tests {
         let json_list = val_to_json(&original_list);
         let roundtrip_list = json_to_val(&json_list, &list_type).unwrap();
         assert_eq!(original_list, roundtrip_list);
+
+        let map_type = get_exported_type("m");
+        let original_map = Val::Map(vec![
+            (Val::String("first".to_string()), Val::U32(1)),
+            (Val::String("second".to_string()), Val::U32(2)),
+        ]);
+        let json_map = val_to_json(&original_map);
+        let roundtrip_map = json_to_val(&json_map, &map_type).unwrap();
+        assert_eq!(original_map, roundtrip_map);
+        assert_eq!(
+            type_to_json_schema(&map_type),
+            json!({
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "key": { "type": "string" },
+                        "value": { "type": "number" }
+                    },
+                    "required": ["key", "value"]
+                }
+            })
+        );
     }
 
     #[test]
@@ -2396,7 +2472,6 @@ mod tests {
 
         let mut config = wasmtime::Config::new();
         config.wasm_component_model(true);
-        config.async_support(true);
         let engine = Engine::new(&config).unwrap();
 
         for file_path in &test_files {

--- a/crates/wassette/Cargo.toml
+++ b/crates/wassette/Cargo.toml
@@ -17,6 +17,7 @@ oci-client = { workspace = true }
 oci-wasm = { workspace = true }
 policy = { workspace = true }
 reqwest = { workspace = true }
+rustls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.11"

--- a/crates/wassette/src/http.rs
+++ b/crates/wassette/src/http.rs
@@ -114,6 +114,37 @@ impl NetworkPolicyHttpHooks {
 
         false
     }
+
+    fn validate_request_uri(&self, uri: &hyper::Uri) -> HttpResult<()> {
+        let Some(host) = uri.host() else {
+            warn!("HTTP request missing host, blocking request");
+            return Err(types::ErrorCode::HttpRequestUriInvalid.into());
+        };
+
+        if !self.is_host_allowed(uri) {
+            let host = host.to_string();
+            let uri_str = uri.to_string();
+
+            warn!(
+                uri = %uri,
+                allowed_hosts = ?self.allowed_hosts,
+                "HTTP request blocked by network policy"
+            );
+
+            if let Ok(mut denial) = self.last_network_denial.lock() {
+                *denial = Some((host, uri_str));
+            }
+
+            return Err(types::ErrorCode::HttpRequestDenied.into());
+        }
+
+        if let Ok(mut denial) = self.last_network_denial.lock() {
+            *denial = None;
+        }
+
+        debug!(uri = %uri, "HTTP request allowed by network policy");
+        Ok(())
+    }
 }
 
 // Add helper methods specifically for WassetteWasiState<crate::wasistate::WasiState>
@@ -161,32 +192,7 @@ impl WasiHttpHooks for NetworkPolicyHttpHooks {
         request: hyper::Request<HyperOutgoingBody>,
         config: OutgoingRequestConfig,
     ) -> HttpResult<HostFutureIncomingResponse> {
-        let uri = request.uri();
-
-        if uri.host().is_none() {
-            warn!("HTTP request missing host, blocking request");
-            return Err(types::ErrorCode::HttpRequestUriInvalid.into());
-        }
-
-        if !self.is_host_allowed(uri) {
-            let host = uri.host().unwrap_or("").to_string();
-            let uri_str = uri.to_string();
-
-            warn!(
-                uri = %uri,
-                allowed_hosts = ?self.allowed_hosts,
-                "HTTP request blocked by network policy"
-            );
-
-            // Record the network denial for later retrieval
-            if let Ok(mut denial) = self.last_network_denial.lock() {
-                *denial = Some((host, uri_str));
-            }
-
-            return Err(types::ErrorCode::HttpRequestDenied.into());
-        }
-
-        debug!(uri = %uri, "HTTP request allowed by network policy");
+        self.validate_request_uri(request.uri())?;
 
         Ok(default_send_request(request, config))
     }
@@ -293,5 +299,31 @@ mod tests {
 
         assert!(state.http_hooks.is_host_allowed(&uri1));
         assert!(state.http_hooks.is_host_allowed(&uri2));
+    }
+
+    #[test]
+    fn test_allowed_request_clears_previous_network_denial() {
+        let mut allowed_hosts = HashSet::new();
+        allowed_hosts.insert("api.example.com".to_string());
+
+        let state = WassetteWasiState::new(MockWasiState, allowed_hosts).unwrap();
+        let denied_uri: hyper::Uri = "https://denied.example.com".parse().unwrap();
+        let allowed_uri: hyper::Uri = "https://api.example.com".parse().unwrap();
+
+        assert!(state.http_hooks.validate_request_uri(&denied_uri).is_err());
+        assert!(state
+            .http_hooks
+            .last_network_denial
+            .lock()
+            .unwrap()
+            .is_some());
+
+        assert!(state.http_hooks.validate_request_uri(&allowed_uri).is_ok());
+        assert!(state
+            .http_hooks
+            .last_network_denial
+            .lock()
+            .unwrap()
+            .is_none());
     }
 }

--- a/crates/wassette/src/http.rs
+++ b/crates/wassette/src/http.rs
@@ -6,11 +6,13 @@ use std::collections::HashSet;
 use anyhow::Result;
 use tracing::{debug, warn};
 use url::Url;
-use wasmtime::component::{Resource, ResourceTable};
 use wasmtime_wasi::{WasiCtxView, WasiView};
-use wasmtime_wasi_http::bindings::http::types;
-use wasmtime_wasi_http::types::{HostFutureIncomingResponse, OutgoingRequestConfig};
-use wasmtime_wasi_http::{HttpResult, WasiHttpView};
+use wasmtime_wasi_http::p2::bindings::http::types;
+use wasmtime_wasi_http::p2::body::HyperOutgoingBody;
+use wasmtime_wasi_http::p2::types::{HostFutureIncomingResponse, OutgoingRequestConfig};
+use wasmtime_wasi_http::p2::{
+    default_send_request, HttpResult, WasiHttpCtxView, WasiHttpHooks, WasiHttpView,
+};
 
 use crate::wasistate::PermissionError;
 
@@ -55,6 +57,10 @@ pub struct WassetteWasiState<T> {
     /// The underlying WASI state
     pub inner: T,
 
+    http_hooks: NetworkPolicyHttpHooks,
+}
+
+struct NetworkPolicyHttpHooks {
     /// Set of allowed hosts for network requests (extracted from policy document)
     allowed_hosts: HashSet<AllowedHost>,
 
@@ -81,12 +87,15 @@ impl<T> WassetteWasiState<T> {
 
         Ok(Self {
             inner,
-            allowed_hosts: parsed_hosts,
-            last_network_denial: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            http_hooks: NetworkPolicyHttpHooks {
+                allowed_hosts: parsed_hosts,
+                last_network_denial: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            },
         })
     }
+}
 
-    /// Check if a host is allowed by the policy
+impl NetworkPolicyHttpHooks {
     fn is_host_allowed(&self, uri: &hyper::Uri) -> bool {
         let request_host = if let Some(host) = uri.host() {
             host.to_string()
@@ -112,7 +121,7 @@ impl WassetteWasiState<crate::wasistate::WasiState> {
     /// Get the last permission error if any occurred (checks both sources)
     pub fn get_last_permission_error(&self) -> Option<PermissionError> {
         // First check if there was a network denial recorded
-        if let Ok(denial) = self.last_network_denial.lock() {
+        if let Ok(denial) = self.http_hooks.last_network_denial.lock() {
             if let Some((host, uri)) = denial.as_ref() {
                 return Some(PermissionError::NetworkDenied {
                     host: host.clone(),
@@ -130,33 +139,26 @@ impl WassetteWasiState<crate::wasistate::WasiState> {
     }
 }
 
-impl<T: WasiView> WasiView for WassetteWasiState<T> {
+impl<T: WasiView + Send> WasiView for WassetteWasiState<T> {
     fn ctx(&mut self) -> WasiCtxView<'_> {
         self.inner.ctx()
     }
 }
 
-impl<T: WasiHttpView> WasiHttpView for WassetteWasiState<T> {
-    fn ctx(&mut self) -> &mut wasmtime_wasi_http::WasiHttpCtx {
-        self.inner.ctx()
+impl WasiHttpView for WassetteWasiState<crate::wasistate::WasiState> {
+    fn http(&mut self) -> WasiHttpCtxView<'_> {
+        WasiHttpCtxView {
+            ctx: &mut self.inner.http,
+            table: &mut self.inner.table,
+            hooks: &mut self.http_hooks,
+        }
     }
+}
 
-    fn table(&mut self) -> &mut ResourceTable {
-        self.inner.table()
-    }
-
-    fn new_response_outparam(
-        &mut self,
-        result: tokio::sync::oneshot::Sender<
-            Result<hyper::Response<wasmtime_wasi_http::body::HyperOutgoingBody>, types::ErrorCode>,
-        >,
-    ) -> wasmtime::Result<Resource<wasmtime_wasi_http::types::HostResponseOutparam>> {
-        self.inner.new_response_outparam(result)
-    }
-
+impl WasiHttpHooks for NetworkPolicyHttpHooks {
     fn send_request(
         &mut self,
-        request: hyper::Request<wasmtime_wasi_http::body::HyperOutgoingBody>,
+        request: hyper::Request<HyperOutgoingBody>,
         config: OutgoingRequestConfig,
     ) -> HttpResult<HostFutureIncomingResponse> {
         let uri = request.uri();
@@ -186,7 +188,7 @@ impl<T: WasiHttpView> WasiHttpView for WassetteWasiState<T> {
 
         debug!(uri = %uri, "HTTP request allowed by network policy");
 
-        self.inner.send_request(request, config)
+        Ok(default_send_request(request, config))
     }
 }
 
@@ -196,56 +198,22 @@ mod tests {
 
     use super::*;
 
-    fn create_mock_wasi_state() -> MockWasiState {
-        MockWasiState
-    }
-
     struct MockWasiState;
-
-    impl WasiHttpView for MockWasiState {
-        fn ctx(&mut self) -> &mut wasmtime_wasi_http::WasiHttpCtx {
-            unimplemented!("Mock for testing")
-        }
-
-        fn table(&mut self) -> &mut ResourceTable {
-            unimplemented!("Mock for testing")
-        }
-
-        fn new_response_outparam(
-            &mut self,
-            _result: tokio::sync::oneshot::Sender<
-                Result<
-                    hyper::Response<wasmtime_wasi_http::body::HyperOutgoingBody>,
-                    types::ErrorCode,
-                >,
-            >,
-        ) -> wasmtime::Result<Resource<wasmtime_wasi_http::types::HostResponseOutparam>> {
-            unimplemented!("Mock for testing")
-        }
-
-        fn send_request(
-            &mut self,
-            _request: hyper::Request<wasmtime_wasi_http::body::HyperOutgoingBody>,
-            _config: OutgoingRequestConfig,
-        ) -> HttpResult<HostFutureIncomingResponse> {
-            unimplemented!("Mock for testing")
-        }
-    }
 
     #[test]
     fn test_host_allowed_exact_match() {
         let mut allowed_hosts = HashSet::new();
         allowed_hosts.insert("api.example.com".to_string());
 
-        let state = WassetteWasiState::new(create_mock_wasi_state(), allowed_hosts).unwrap();
+        let state = WassetteWasiState::new(MockWasiState, allowed_hosts).unwrap();
 
         let uri1: hyper::Uri = "http://api.example.com".parse().unwrap();
         let uri2: hyper::Uri = "http://other.example.com".parse().unwrap();
         let uri3: hyper::Uri = "http://malicious.com".parse().unwrap();
 
-        assert!(state.is_host_allowed(&uri1));
-        assert!(!state.is_host_allowed(&uri2));
-        assert!(!state.is_host_allowed(&uri3));
+        assert!(state.http_hooks.is_host_allowed(&uri1));
+        assert!(!state.http_hooks.is_host_allowed(&uri2));
+        assert!(!state.http_hooks.is_host_allowed(&uri3));
     }
 
     #[test]
@@ -253,15 +221,15 @@ mod tests {
         let mut allowed_hosts = HashSet::new();
         allowed_hosts.insert("https://api.example.com".to_string());
 
-        let state = WassetteWasiState::new(create_mock_wasi_state(), allowed_hosts).unwrap();
+        let state = WassetteWasiState::new(MockWasiState, allowed_hosts).unwrap();
 
         let uri1: hyper::Uri = "http://api.example.com".parse().unwrap();
         let uri2: hyper::Uri = "https://api.example.com".parse().unwrap();
         let uri3: hyper::Uri = "http://api.example.com".parse().unwrap();
 
-        assert!(!state.is_host_allowed(&uri1));
-        assert!(state.is_host_allowed(&uri2));
-        assert!(!state.is_host_allowed(&uri3));
+        assert!(!state.http_hooks.is_host_allowed(&uri1));
+        assert!(state.http_hooks.is_host_allowed(&uri2));
+        assert!(!state.http_hooks.is_host_allowed(&uri3));
     }
 
     #[test]
@@ -269,13 +237,13 @@ mod tests {
         let mut allowed_hosts = HashSet::new();
         allowed_hosts.insert("api.example.com".to_string());
 
-        let state = WassetteWasiState::new(create_mock_wasi_state(), allowed_hosts).unwrap();
+        let state = WassetteWasiState::new(MockWasiState, allowed_hosts).unwrap();
 
         let uri1: hyper::Uri = "http://api.example.com:8080".parse().unwrap();
         let uri2: hyper::Uri = "http://api.example.com:443".parse().unwrap();
 
-        assert!(state.is_host_allowed(&uri1));
-        assert!(state.is_host_allowed(&uri2));
+        assert!(state.http_hooks.is_host_allowed(&uri1));
+        assert!(state.http_hooks.is_host_allowed(&uri2));
     }
 
     #[test]
@@ -284,21 +252,21 @@ mod tests {
         allowed_hosts.insert("https://secure.api.com".to_string());
         allowed_hosts.insert("api.example.com".to_string()); // scheme-agnostic
 
-        let state = WassetteWasiState::new(create_mock_wasi_state(), allowed_hosts).unwrap();
+        let state = WassetteWasiState::new(MockWasiState, allowed_hosts).unwrap();
 
         // Scheme-specific host should only match HTTPS
         let https_secure: hyper::Uri = "https://secure.api.com".parse().unwrap();
         let http_secure: hyper::Uri = "http://secure.api.com".parse().unwrap();
 
-        assert!(state.is_host_allowed(&https_secure));
-        assert!(!state.is_host_allowed(&http_secure));
+        assert!(state.http_hooks.is_host_allowed(&https_secure));
+        assert!(!state.http_hooks.is_host_allowed(&http_secure));
 
         // Scheme-agnostic host should match both
         let https_example: hyper::Uri = "https://api.example.com".parse().unwrap();
         let http_example: hyper::Uri = "http://api.example.com".parse().unwrap();
 
-        assert!(state.is_host_allowed(&https_example));
-        assert!(state.is_host_allowed(&http_example));
+        assert!(state.http_hooks.is_host_allowed(&https_example));
+        assert!(state.http_hooks.is_host_allowed(&http_example));
     }
 
     #[test]
@@ -307,7 +275,7 @@ mod tests {
         allowed_hosts.insert("http://".to_string());
         allowed_hosts.insert("".to_string());
 
-        match WassetteWasiState::new(create_mock_wasi_state(), allowed_hosts) {
+        match WassetteWasiState::new(MockWasiState, allowed_hosts) {
             Ok(_) => panic!("Expected error, got Ok"),
             Err(e) => assert!(e.to_string().contains("Invalid host format")),
         }
@@ -318,12 +286,12 @@ mod tests {
         let mut allowed_hosts = HashSet::new();
         allowed_hosts.insert("api.example.com".to_string());
 
-        let state = WassetteWasiState::new(create_mock_wasi_state(), allowed_hosts).unwrap();
+        let state = WassetteWasiState::new(MockWasiState, allowed_hosts).unwrap();
 
         let uri1: hyper::Uri = "http://api.example.com".parse().unwrap();
         let uri2: hyper::Uri = "http://API.EXAMPLE.COM".parse().unwrap();
 
-        assert!(state.is_host_allowed(&uri1));
-        assert!(state.is_host_allowed(&uri2));
+        assert!(state.http_hooks.is_host_allowed(&uri1));
+        assert!(state.http_hooks.is_host_allowed(&uri2));
     }
 }

--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -466,6 +466,7 @@ impl LifecycleManager {
         let instance_pre = self
             .runtime
             .instantiate_pre(&component)
+            .map_err(anyhow::Error::from)
             .context("failed to instantiate component")?;
 
         // Extract package docs from wasm bytes
@@ -886,6 +887,7 @@ impl LifecycleManager {
         let precompiled_data = self
             .runtime
             .precompile_component(wasm_bytes)
+            .map_err(anyhow::Error::from)
             .context("Failed to precompile component")?;
 
         self.storage
@@ -927,6 +929,7 @@ impl LifecycleManager {
             .context("Failed to read wasm file")?;
 
         let component = Component::new(self.runtime.as_ref(), &wasm_bytes)
+            .map_err(anyhow::Error::from)
             .context("Failed to compile component")?;
 
         // Save precompiled version for next time (async, don't block on this)
@@ -1052,9 +1055,15 @@ impl LifecycleManager {
         };
 
         let params: serde_json::Value = serde_json::from_str(parameters)?;
-        let argument_vals = json_to_vals(&params, &func.params(&store))?;
+        let func_type = func.ty(&store);
+        let parameter_types = func_type
+            .params()
+            .map(|(name, ty)| (name.to_string(), ty))
+            .collect::<Vec<_>>();
+        let argument_vals = json_to_vals(&params, &parameter_types)?;
 
-        let mut results = create_placeholder_results(&func.results(&store));
+        let result_types = func_type.results().collect::<Vec<_>>();
+        let mut results = create_placeholder_results(&result_types);
 
         let execution_start = Instant::now();
 
@@ -1073,7 +1082,7 @@ impl LifecycleManager {
                 return Err(anyhow!(perm_error.to_user_message(component_id)));
             }
             // Otherwise, return the original WASM execution error
-            return Err(e);
+            return Err(e.into());
         }
 
         let result_json = vals_to_json(&results);

--- a/crates/wassette/src/runtime_context.rs
+++ b/crates/wassette/src/runtime_context.rs
@@ -23,15 +23,17 @@ pub struct RuntimeContext {
 impl RuntimeContext {
     /// Build a runtime context with the standard configuration used by Wassette.
     pub fn initialize() -> Result<Self> {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
         let mut config = wasmtime::Config::new();
         config.wasm_component_model(true);
-        config.async_support(true);
+        config.wasm_component_model_map(true);
 
         let engine = Arc::new(Engine::new(&config)?);
 
         let mut linker = Linker::new(engine.as_ref());
         wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
-        wasmtime_wasi_http::add_only_http_to_linker_async(&mut linker)?;
+        wasmtime_wasi_http::p2::add_only_http_to_linker_async(&mut linker)?;
         wasmtime_wasi_config::add_to_linker(
             &mut linker,
             |h: &mut WassetteWasiState<WasiState>| WasiConfig::from(&h.inner.wasi_config_vars),

--- a/crates/wassette/src/runtime_context.rs
+++ b/crates/wassette/src/runtime_context.rs
@@ -23,7 +23,12 @@ pub struct RuntimeContext {
 impl RuntimeContext {
     /// Build a runtime context with the standard configuration used by Wassette.
     pub fn initialize() -> Result<Self> {
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        if rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .is_err()
+        {
+            tracing::debug!("Using the previously installed rustls crypto provider");
+        }
 
         let mut config = wasmtime::Config::new();
         config.wasm_component_model(true);

--- a/crates/wassette/src/wasistate.rs
+++ b/crates/wassette/src/wasistate.rs
@@ -6,10 +6,10 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use policy::{AccessType, PolicyDocument};
-use wasmtime::component::ResourceTable;
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView};
 use wasmtime_wasi_config::WasiConfigVariables;
-use wasmtime_wasi_http::{WasiHttpCtx, WasiHttpView};
+use wasmtime_wasi_http::p2::{WasiHttpCtxView, WasiHttpView};
+use wasmtime_wasi_http::WasiHttpCtx;
 
 /// Represents a permission-related error that occurred during component execution
 #[derive(Debug, Clone)]
@@ -73,7 +73,7 @@ impl wasmtime::ResourceLimiter for CustomResourceLimiter {
         current: usize,
         desired: usize,
         _maximum: Option<usize>,
-    ) -> anyhow::Result<bool> {
+    ) -> wasmtime::Result<bool> {
         self.limits.memory_growing(current, desired, _maximum)
     }
 
@@ -82,7 +82,7 @@ impl wasmtime::ResourceLimiter for CustomResourceLimiter {
         current: usize,
         desired: usize,
         _maximum: Option<usize>,
-    ) -> anyhow::Result<bool> {
+    ) -> wasmtime::Result<bool> {
         self.limits.table_growing(current, desired, _maximum)
     }
 }
@@ -107,12 +107,12 @@ impl wasmtime_wasi::WasiView for WasiState {
 }
 
 impl WasiHttpView for WasiState {
-    fn ctx(&mut self) -> &mut WasiHttpCtx {
-        &mut self.http
-    }
-
-    fn table(&mut self) -> &mut ResourceTable {
-        &mut self.table
+    fn http(&mut self) -> WasiHttpCtxView<'_> {
+        WasiHttpCtxView {
+            ctx: &mut self.http,
+            table: &mut self.table,
+            hooks: Default::default(),
+        }
     }
 }
 

--- a/crates/wassette/src/wasistate.rs
+++ b/crates/wassette/src/wasistate.rs
@@ -8,7 +8,6 @@ use std::sync::{Arc, Mutex};
 use policy::{AccessType, PolicyDocument};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView};
 use wasmtime_wasi_config::WasiConfigVariables;
-use wasmtime_wasi_http::p2::{WasiHttpCtxView, WasiHttpView};
 use wasmtime_wasi_http::WasiHttpCtx;
 
 /// Represents a permission-related error that occurred during component execution
@@ -102,16 +101,6 @@ impl wasmtime_wasi::WasiView for WasiState {
         WasiCtxView {
             ctx: &mut self.ctx,
             table: &mut self.table,
-        }
-    }
-}
-
-impl WasiHttpView for WasiState {
-    fn http(&mut self) -> WasiHttpCtxView<'_> {
-        WasiHttpCtxView {
-            ctx: &mut self.http,
-            table: &mut self.table,
-            hooks: Default::default(),
         }
     }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754534980,
-        "narHash": "sha256-8cAquqasyPRvgJfKVKxz+gQ+SRoRxiHhX91Avtl9Rn8=",
+        "lastModified": 1785907205,
+        "narHash": "sha256-Ds1vTi53af4wDMAveSR/K0JnywDslLwmgwhVIiwnNmY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "89e92794124b93bddb5f8f92485ed924bd179287",
+        "rev": "c5cb13481d718fac906aa9cfd85f9b60e1a546cb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,8 @@
           inherit system overlays;
         };
 
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
-          extensions = [ "rust-src" "rust-analyzer" ];
+        rustToolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
+          extensions = [ "rustfmt" "clippy" "rust-src" "rust-analyzer" ];
           targets = [ "wasm32-wasip2" "wasm32-wasip1" "wasm32-unknown-unknown" ];
         };
 
@@ -35,6 +35,7 @@
             filter = path: type:
               (craneLib.filterCargoSources path type)
               || (pkgs.lib.hasSuffix "README.md" path)
+              || (pkgs.lib.hasSuffix "rust-toolchain.toml" path)
               || (pkgs.lib.hasSuffix "component-registry.json" path);
           };
           strictDeps = true;


### PR DESCRIPTION
- Upgrade Wasmtime and WASI crates from 36.0.13 to 47.0.3.
- Migrate component APIs and WASI HTTP hooks while preserving network policy enforcement.
- Add component map support and align Nix/security configuration.

Closes #705