### PR TITLE
chore(release): bump version to 0.6.0-test1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "wassette-mcp-server"
-version = "0.5.0"
+version = "0.6.0-test1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0-test1"
 license = "MIT"
 license-file = "LICENSE"
 


### PR DESCRIPTION
This pull request prepares the 0.6.0-test1 release by updating the version in `Cargo.toml` and `Cargo.lock`. After merge, run the Release workflow (e.g. `gh workflow run release.yml -f version=0.6.0-test1`) to build, tag `v0.6.0-test1`, and publish the GitHub release. Versions with a suffix are prereleases and skip stable-release updates.