### PR TITLE
chore: remove Justfile recipes that depend on missing Dockerfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -206,20 +206,6 @@ docs-serve:
 docs-watch:
     cd docs && mdbook serve
 
-# CI Docker commands - automatically handle user mapping to prevent permission issues
-ci-local:
-    docker build \
-        --build-arg USER_ID=$(id -u) \
-        --build-arg GROUP_ID=$(id -g) \
-        -f Dockerfile.ci \
-        --target ci-test \
-        -t wassette-ci-local .
-    docker run --rm \
-        -v $(PWD):/workspace \
-        -w /workspace \
-        -e GITHUB_TOKEN \
-        wassette-ci-local just ci-build-test
-
 ci-build-test:
     just build-test-components
     cargo build --workspace
@@ -231,11 +217,3 @@ ci-build-test-ghcr:
     cargo build --workspace
     cargo test --workspace -- --nocapture --include-ignored
     cargo test --doc --workspace -- --nocapture
-
-ci-cache-info:
-    docker system df
-    docker images wassette-ci-*
-
-ci-clean:
-    docker rmi $(docker images -q wassette-ci-* 2>/dev/null) 2>/dev/null || true
-    docker builder prune -f


### PR DESCRIPTION
'just ci-local' runs 'docker build -f Dockerfile.ci', but Dockerfile.ci has never existed in this repository. The only Dockerfiles ever present were Dockerfile and Dockerfile.prebuilt, added in #369 and removed in 3e394b5 (remove docker deployment support). So this recipe fails for anyone who runs it, and always has.

ci-cache-info and ci-clean go with it: both only operate on the wassette-ci-* images that ci-local was supposed to build, so neither has anything to act on.

ci-build-test and ci-build-test-ghcr are kept. They are plain cargo recipes with no Docker dependency, and both are documented in docs/development/getting-started.md.

Nothing outside the Justfile referenced any of the three removed recipes.

Refs #278