### PR TITLE
test: stop asserting the generated bash completion function name

### DIFF
--- a/crates/wassette-mcp-server/tests/cli_integration_test.rs
+++ b/crates/wassette-mcp-server/tests/cli_integration_test.rs
@@ -778,10 +778,16 @@ async fn test_cli_autocomplete_bash() -> Result<()> {
         "Autocomplete bash command failed with stderr: {stderr}"
     );
 
-    // Verify the output contains bash completion script markers
+    // Verify the output contains bash completion script markers.
+    // Deliberately does not assert the generated function's name: clap_complete
+    // renamed it from _wassette-mcp-server to _wassette__mcp__server in 4.6.9.
     assert!(
-        stdout.contains("_wassette-mcp-server"),
-        "Bash completion should contain completion function"
+        stdout.contains("complete -F"),
+        "Bash completion should register a completion function"
+    );
+    assert!(
+        stdout.contains("wassette-mcp-server"),
+        "Bash completion should be registered for wassette-mcp-server"
     );
     assert!(
         stdout.contains("COMPREPLY"),


### PR DESCRIPTION
clap_complete 4.6.9 renamed the top-level bash completion function. In 4.6.8 it was declared as _{name} using the raw bin name, producing _wassette-mcp-server. In 4.6.9 the 'complete -F' line switched to _{fn_name}, where fn_name is bin_name.replace('-', "__"), producing _wassette__mcp__server.

The CLI sets name = "wassette-mcp-server" and passes cmd.get_name() to generate(), so the string this test asserted no longer appears anywhere in the output. The bump landed in #742 and fails on main, which means it fails on every PR branched from it.

Assert on 'complete -F' and on the command name instead. Both are stable across this rename, and together they still check that the output is a bash completion script registered for the right command. COMPREPLY is unchanged and still asserted.

The zsh, fish and powershell tests already assert generic markers and are unaffected.

#742 auto-merged and broke this test.