### PR TITLE
feat(serve): make the Streamable HTTP Host allowlist configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/crates/wassette-mcp-server/src/cli_handlers.rs
+++ b/crates/wassette-mcp-server/src/cli_handlers.rs
@@ -90,6 +90,7 @@ pub async fn create_lifecycle_manager(component_dir: Option<PathBuf>) -> Result<
             }),
             environment_vars: std::collections::HashMap::new(),
             bind_address: "127.0.0.1:9001".to_string(),
+            allowed_hosts: None,
         }
     } else {
         config::Config::from_serve(&crate::commands::Serve {
@@ -100,6 +101,7 @@ pub async fn create_lifecycle_manager(component_dir: Option<PathBuf>) -> Result<
             disable_builtin_tools: false,
             bind_address: None,
             manifest: None,
+            allowed_hosts: None,
         })
         .context("Failed to load configuration")?
     };
@@ -110,6 +112,7 @@ pub async fn create_lifecycle_manager(component_dir: Option<PathBuf>) -> Result<
         secrets_dir,
         environment_vars,
         bind_address: _,
+        allowed_hosts: _,
     } = config;
 
     LifecycleManager::builder(component_dir)

--- a/crates/wassette-mcp-server/src/commands.rs
+++ b/crates/wassette-mcp-server/src/commands.rs
@@ -156,6 +156,17 @@ pub struct Serve {
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub manifest: Option<PathBuf>,
+
+    /// Hostname or host:port authority to accept in the inbound `Host` header for
+    /// Streamable HTTP. Repeat the flag to allow several. When unset, only loopback
+    /// hosts are accepted, which blocks requests addressed by service or container name.
+    ///
+    /// Skipped during serialization and applied explicitly in `Config::from_serve`, as
+    /// `env_vars` and `env_file` are, because figment's `admerge` would concatenate this
+    /// list with a configured one rather than overriding it.
+    #[arg(long = "allowed-host", value_name = "HOST")]
+    #[serde(skip)]
+    pub allowed_hosts: Option<Vec<String>>,
 }
 
 /// HTTP transport options for the Serve command

--- a/crates/wassette-mcp-server/src/commands.rs
+++ b/crates/wassette-mcp-server/src/commands.rs
@@ -158,12 +158,12 @@ pub struct Serve {
     pub manifest: Option<PathBuf>,
 
     /// Hostname or host:port authority to accept in the inbound `Host` header for
-    /// Streamable HTTP. Repeat the flag to allow several. When unset, only loopback
-    /// hosts are accepted, which blocks requests addressed by service or container name.
-    ///
-    /// Skipped during serialization and applied explicitly in `Config::from_serve`, as
-    /// `env_vars` and `env_file` are, because figment's `admerge` would concatenate this
-    /// list with a configured one rather than overriding it.
+    /// Streamable HTTP. Repeat the flag to allow several. Replaces the default allowlist
+    /// rather than adding to it, so include `localhost` and `127.0.0.1` explicitly if
+    /// loopback clients must keep working. When unset, only loopback is accepted.
+    // Serialization is skipped and the value applied explicitly in `Config::from_serve`,
+    // as `env_vars` and `env_file` are, because figment's `admerge` would concatenate
+    // this list with a configured one rather than overriding it.
     #[arg(long = "allowed-host", value_name = "HOST")]
     #[serde(skip)]
     pub allowed_hosts: Option<Vec<String>>,

--- a/crates/wassette-mcp-server/src/config.rs
+++ b/crates/wassette-mcp-server/src/config.rs
@@ -675,7 +675,7 @@ bind_address = "0.0.0.0:8080"
     }
 
     #[test]
-    fn test_allowed_hosts_empty_toml_list_is_treated_as_unset() {
+    fn test_allowed_hosts_empty_toml_list_extracts_as_empty_vec() {
         temp_env::with_var("WASSETTE_ALLOWED_HOSTS", None::<&str>, || {
             let temp_dir = TempDir::new().unwrap();
             let config_path = temp_dir.path().join("config.toml");
@@ -684,10 +684,10 @@ bind_address = "0.0.0.0:8080"
             let config = Config::new_from_path(&empty_test_cli_config(), &config_path)
                 .expect("Failed to create config");
 
-            // An empty list reaches the transport as "allow every Host", so serve must
-            // fall back to the loopback default rather than passing it through. The
-            // guard for that lives at the call site in main.rs; this pins the shape the
-            // guard depends on.
+            // Deliberately Some(vec![]) rather than None: the empty list survives
+            // extraction, and the guard that stops it reaching the transport lives at
+            // the call site in main.rs, because an empty list there would mean "allow
+            // every Host". This pins the shape that guard depends on.
             assert_eq!(config.allowed_hosts, Some(vec![]));
         });
     }

--- a/crates/wassette-mcp-server/src/config.rs
+++ b/crates/wassette-mcp-server/src/config.rs
@@ -625,6 +625,74 @@ bind_address = "0.0.0.0:8080"
     }
 
     #[test]
+    fn test_allowed_hosts_env_var_replaces_config_file_list() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.toml");
+        fs::write(&config_path, "allowed_hosts = [\"from-file\"]\n").unwrap();
+
+        temp_env::with_var("WASSETTE_ALLOWED_HOSTS", Some("from-env"), || {
+            let config = Config::new_from_path(&empty_test_cli_config(), &config_path)
+                .unwrap_or_else(|e| {
+                    panic!("Failed to create config: {e}");
+                });
+
+            // Not ["from-file", "from-env"]. figment's admerge concatenates sequences,
+            // which is why this field is resolved outside figment.
+            assert_eq!(
+                config.allowed_hosts,
+                Some(vec!["from-env".to_string()]),
+                "the environment value must replace the file list, not extend it"
+            );
+        });
+    }
+
+    #[test]
+    fn test_allowed_hosts_cli_replaces_config_file_list() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.toml");
+        fs::write(&config_path, "allowed_hosts = [\"from-file\"]\n").unwrap();
+
+        temp_env::with_vars(
+            vec![
+                ("WASSETTE_ALLOWED_HOSTS", None),
+                ("WASSETTE_CONFIG_FILE", Some(config_path.to_str().unwrap())),
+            ],
+            || {
+                let cli_config = Serve {
+                    allowed_hosts: Some(vec!["from-cli".to_string()]),
+                    ..empty_test_cli_config()
+                };
+
+                let config = Config::from_serve(&cli_config).expect("Failed to create config");
+
+                assert_eq!(
+                    config.allowed_hosts,
+                    Some(vec!["from-cli".to_string()]),
+                    "the CLI value must replace the file list, not extend it"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_allowed_hosts_empty_toml_list_is_treated_as_unset() {
+        temp_env::with_var("WASSETTE_ALLOWED_HOSTS", None::<&str>, || {
+            let temp_dir = TempDir::new().unwrap();
+            let config_path = temp_dir.path().join("config.toml");
+            fs::write(&config_path, "allowed_hosts = []\n").unwrap();
+
+            let config = Config::new_from_path(&empty_test_cli_config(), &config_path)
+                .expect("Failed to create config");
+
+            // An empty list reaches the transport as "allow every Host", so serve must
+            // fall back to the loopback default rather than passing it through. The
+            // guard for that lives at the call site in main.rs; this pins the shape the
+            // guard depends on.
+            assert_eq!(config.allowed_hosts, Some(vec![]));
+        });
+    }
+
+    #[test]
     fn test_allowed_hosts_from_config_file() {
         temp_env::with_var("WASSETTE_ALLOWED_HOSTS", None::<&str>, || {
             let temp_dir = TempDir::new().unwrap();

--- a/crates/wassette-mcp-server/src/config.rs
+++ b/crates/wassette-mcp-server/src/config.rs
@@ -37,6 +37,16 @@ fn default_secrets_dir() -> PathBuf {
     })
 }
 
+/// Split a comma-separated `Host` allowlist, dropping empty entries and surrounding
+/// whitespace. Returns an empty vector when nothing usable is present.
+fn parse_allowed_hosts(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|host| host.trim())
+        .filter(|host| !host.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
 fn default_bind_address() -> String {
     // Default bind address using PORT and BIND_HOST environment variables (twelve-factor app compliance).
     // This is only used when bind_address is not set via CLI, config file, or other higher-precedence sources.
@@ -64,6 +74,15 @@ pub struct Config {
     /// Configured via PORT and BIND_HOST environment variables or CLI/config file
     #[serde(default = "default_bind_address", rename = "bind_address")]
     pub bind_address: String,
+
+    /// Hostnames or `host:port` authorities accepted in the inbound `Host` header for
+    /// Streamable HTTP.
+    ///
+    /// `None` leaves the transport's own default in place, which accepts loopback only
+    /// as protection against DNS rebinding. Set this when the server is addressed by a
+    /// service name, container name or DNS name rather than by `localhost`.
+    #[serde(default)]
+    pub allowed_hosts: Option<Vec<String>>,
 }
 
 impl Config {
@@ -97,14 +116,36 @@ impl Config {
         // Build figment config, excluding bind_address from WASSETTE_ environment variables.
         // Instead, bind_address uses PORT and BIND_HOST env vars as defaults (via default_bind_address())
         // when not explicitly set via CLI or config file.
-        let env_provider = Env::prefixed("WASSETTE_").filter(|key| key != "bind_address");
+        //
+        // allowed_hosts is excluded for a different reason: it is a list, and the generic
+        // env provider has no separator configured, so `WASSETTE_ALLOWED_HOSTS=a,b` would
+        // arrive as one string. It is parsed explicitly below instead of teaching the
+        // provider to split every value.
+        let env_provider = Env::prefixed("WASSETTE_")
+            .filter(|key| key != "bind_address" && key != "allowed_hosts");
 
-        figment::Figment::new()
+        let mut config: Self = figment::Figment::new()
             .admerge(Toml::file(config_file_path))
             .admerge(env_provider)
             .admerge(Serialized::defaults(cli_config))
             .extract()
-            .context("Unable to merge configs")
+            .context("Unable to merge configs")?;
+
+        // Applied after extraction rather than as another figment layer because `admerge`
+        // concatenates sequences instead of replacing them, so a file value and an env
+        // value would combine into one longer allowlist rather than the env winning.
+        //
+        // An empty or whitespace-only value is ignored rather than treated as an empty
+        // list: an empty list disables Host validation entirely in the transport, and
+        // that must not be reachable by accident.
+        if let Some(raw) = std::env::var_os("WASSETTE_ALLOWED_HOSTS") {
+            let hosts = parse_allowed_hosts(&raw.to_string_lossy());
+            if !hosts.is_empty() {
+                config.allowed_hosts = Some(hosts);
+            }
+        }
+
+        Ok(config)
     }
 
     /// Creates a new config from a Run struct for local stdio transport
@@ -166,6 +207,16 @@ impl Config {
             config.environment_vars.entry(key).or_insert(value);
         }
 
+        // Highest precedence, so it lands after the config file and WASSETTE_ALLOWED_HOSTS.
+        // Empty entries are dropped; if nothing usable remains the lower-precedence value
+        // stands rather than becoming an empty list, which would disable Host validation.
+        if let Some(cli_hosts) = &serve_config.allowed_hosts {
+            let hosts = parse_allowed_hosts(&cli_hosts.join(","));
+            if !hosts.is_empty() {
+                config.allowed_hosts = Some(hosts);
+            }
+        }
+
         Ok(config)
     }
 }
@@ -207,6 +258,7 @@ mod tests {
             disable_builtin_tools: false,
             bind_address: None,
             manifest: None,
+            allowed_hosts: None,
         }
     }
 
@@ -219,6 +271,7 @@ mod tests {
             disable_builtin_tools: false,
             bind_address: None,
             manifest: None,
+            allowed_hosts: None,
         }
     }
 
@@ -412,6 +465,7 @@ bind_address = "0.0.0.0:8080"
             disable_builtin_tools: false,
             bind_address: Some("192.168.1.100:9090".to_string()),
             manifest: None,
+            allowed_hosts: None,
         };
 
         let config =
@@ -464,5 +518,123 @@ bind_address = "0.0.0.0:8080"
                 assert_eq!(config.bind_address, "0.0.0.0:3000");
             },
         );
+    }
+
+    #[test]
+    fn test_allowed_hosts_defaults_to_none() {
+        temp_env::with_var("WASSETTE_ALLOWED_HOSTS", None::<&str>, || {
+            let temp_dir = TempDir::new().unwrap();
+            let non_existent_config = temp_dir.path().join("non_existent_config.toml");
+
+            let config = Config::new_from_path(&empty_test_cli_config(), &non_existent_config)
+                .expect("Failed to create config");
+
+            // None leaves the transport's loopback-only default untouched. An empty
+            // Vec would disable Host validation entirely, so it must not be the default.
+            assert_eq!(config.allowed_hosts, None);
+        });
+    }
+
+    #[test]
+    fn test_allowed_hosts_env_var_is_split_on_commas() {
+        temp_env::with_var(
+            "WASSETTE_ALLOWED_HOSTS",
+            Some("wassette.internal, example.com:8080 ,"),
+            || {
+                let temp_dir = TempDir::new().unwrap();
+                let non_existent_config = temp_dir.path().join("non_existent_config.toml");
+
+                let config = Config::new_from_path(&empty_test_cli_config(), &non_existent_config)
+                    .expect("Failed to create config");
+
+                assert_eq!(
+                    config.allowed_hosts,
+                    Some(vec![
+                        "wassette.internal".to_string(),
+                        "example.com:8080".to_string()
+                    ]),
+                    "entries should be trimmed and empty ones dropped"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_allowed_hosts_empty_env_var_is_ignored() {
+        temp_env::with_var("WASSETTE_ALLOWED_HOSTS", Some(" , "), || {
+            let temp_dir = TempDir::new().unwrap();
+            let non_existent_config = temp_dir.path().join("non_existent_config.toml");
+
+            let config = Config::new_from_path(&empty_test_cli_config(), &non_existent_config)
+                .expect("Failed to create config");
+
+            // Falling through to None keeps the loopback default rather than
+            // silently disabling Host validation.
+            assert_eq!(config.allowed_hosts, None);
+        });
+    }
+
+    #[test]
+    fn test_allowed_hosts_cli_overrides_env_var() {
+        let temp_dir = TempDir::new().unwrap();
+        let non_existent_config = temp_dir.path().join("non_existent_config.toml");
+
+        temp_env::with_vars(
+            vec![
+                ("WASSETTE_ALLOWED_HOSTS", Some("from-env")),
+                (
+                    "WASSETTE_CONFIG_FILE",
+                    Some(non_existent_config.to_str().unwrap()),
+                ),
+            ],
+            || {
+                let cli_config = Serve {
+                    allowed_hosts: Some(vec!["from-cli".to_string()]),
+                    ..empty_test_cli_config()
+                };
+
+                // from_serve is the path that applies the CLI value, mirroring how
+                // env_vars and env_file are handled.
+                let config = Config::from_serve(&cli_config).expect("Failed to create config");
+
+                assert_eq!(config.allowed_hosts, Some(vec!["from-cli".to_string()]));
+            },
+        );
+    }
+
+    #[test]
+    fn test_allowed_hosts_env_var_used_when_no_cli_value() {
+        let temp_dir = TempDir::new().unwrap();
+        let non_existent_config = temp_dir.path().join("non_existent_config.toml");
+
+        temp_env::with_vars(
+            vec![
+                ("WASSETTE_ALLOWED_HOSTS", Some("from-env")),
+                (
+                    "WASSETTE_CONFIG_FILE",
+                    Some(non_existent_config.to_str().unwrap()),
+                ),
+            ],
+            || {
+                let config =
+                    Config::from_serve(&empty_test_cli_config()).expect("Failed to create config");
+
+                assert_eq!(config.allowed_hosts, Some(vec!["from-env".to_string()]));
+            },
+        );
+    }
+
+    #[test]
+    fn test_allowed_hosts_from_config_file() {
+        temp_env::with_var("WASSETTE_ALLOWED_HOSTS", None::<&str>, || {
+            let temp_dir = TempDir::new().unwrap();
+            let config_path = temp_dir.path().join("config.toml");
+            fs::write(&config_path, "allowed_hosts = [\"from-file\"]\n").unwrap();
+
+            let config = Config::new_from_path(&empty_test_cli_config(), &config_path)
+                .expect("Failed to create config");
+
+            assert_eq!(config.allowed_hosts, Some(vec!["from-file".to_string()]));
+        });
     }
 }

--- a/crates/wassette-mcp-server/src/main.rs
+++ b/crates/wassette-mcp-server/src/main.rs
@@ -12,7 +12,7 @@ use mcp_server::{handle_tools_list, LifecycleManager};
 use rmcp::service::serve_server;
 use rmcp::transport::stdio as stdio_transport;
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
-use rmcp::transport::streamable_http_server::StreamableHttpService;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 use serde_json::{json, Map};
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
@@ -107,6 +107,7 @@ async fn main() -> Result<()> {
                     secrets_dir,
                     environment_vars,
                     bind_address: _,
+                    allowed_hosts: _,
                 } = config;
 
                 let lifecycle_manager = LifecycleManager::builder(component_dir)
@@ -197,6 +198,7 @@ async fn main() -> Result<()> {
                     secrets_dir,
                     environment_vars,
                     bind_address,
+                    allowed_hosts,
                 } = config;
 
                 // Keep a clone of component_dir for provisioning
@@ -263,10 +265,25 @@ async fn main() -> Result<()> {
                         "Starting MCP server on {} with streamable HTTP transport. Components will load in the background.",
                         bind_address
                     );
+                        // The transport accepts loopback Host headers only unless told
+                        // otherwise, so a server addressed as `http://wassette:9001/mcp`
+                        // is refused before MCP dispatch until allowed_hosts is set.
+                        let http_config = match allowed_hosts.as_deref() {
+                            Some(hosts) if !hosts.is_empty() => {
+                                tracing::info!(
+                                    allowed_hosts = ?hosts,
+                                    "Accepting these Host values on the MCP endpoint"
+                                );
+                                StreamableHttpServerConfig::default()
+                                    .with_allowed_hosts(hosts.to_vec())
+                            }
+                            _ => StreamableHttpServerConfig::default(),
+                        };
+
                         let service = StreamableHttpService::new(
                             move || Ok(server.clone()),
                             LocalSessionManager::default().into(),
-                            Default::default(),
+                            http_config,
                         );
 
                         let router = axum::Router::new()

--- a/crates/wassette-mcp-server/tests/dns_rebinding_integration_test.rs
+++ b/crates/wassette-mcp-server/tests/dns_rebinding_integration_test.rs
@@ -101,6 +101,14 @@ impl Drop for ServerGuard {
 }
 
 async fn spawn_server(port: u16, component_dir: &Path) -> Result<ServerGuard> {
+    spawn_server_with_args(port, component_dir, &[]).await
+}
+
+async fn spawn_server_with_args(
+    port: u16,
+    component_dir: &Path,
+    extra_args: &[String],
+) -> Result<ServerGuard> {
     let child = Command::new(env!("CARGO_BIN_EXE_wassette"))
         .args([
             "serve",
@@ -109,6 +117,7 @@ async fn spawn_server(port: u16, component_dir: &Path) -> Result<ServerGuard> {
             &format!("127.0.0.1:{port}"),
             &format!("--component-dir={}", component_dir.display()),
         ])
+        .args(extra_args)
         .env("RUST_LOG", "error")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -138,6 +147,41 @@ async fn dns_rebinding_foreign_host_is_rejected() -> Result<()> {
         forged_status, 403,
         "forged Host `{forged_host}` must be rejected with 403 to prevent DNS \
          rebinding (got {forged_status})"
+    );
+
+    Ok(())
+}
+
+/// A deployment addressed by service or container name needs its own `Host` accepted.
+/// `--allowed-host` must widen the list to exactly what is configured, and no further:
+/// the protection above still has to hold for every other value.
+#[tokio::test]
+async fn configured_allowed_host_is_accepted_and_others_still_rejected() -> Result<()> {
+    const CONFIGURED_HOST: &str = "wassette.internal";
+
+    let port = find_open_port().await?;
+    let temp_dir = tempfile::tempdir()?;
+    let _server = spawn_server_with_args(
+        port,
+        temp_dir.path(),
+        &["--allowed-host".to_string(), CONFIGURED_HOST.to_string()],
+    )
+    .await?;
+    wait_until_listening(port).await?;
+
+    let configured_host = format!("{CONFIGURED_HOST}:{port}");
+    let configured_status = post_initialize_status(port, &configured_host).await?;
+    assert_eq!(
+        configured_status, 200,
+        "configured Host `{configured_host}` should be accepted (got {configured_status})"
+    );
+
+    let forged_host = format!("{FORGED_HOST}:{port}");
+    let forged_status = post_initialize_status(port, &forged_host).await?;
+    assert_eq!(
+        forged_status, 403,
+        "Host `{forged_host}` is not in the configured allowlist and must still be \
+         rejected with 403 (got {forged_status})"
     );
 
     Ok(())

--- a/crates/wassette-mcp-server/tests/dns_rebinding_integration_test.rs
+++ b/crates/wassette-mcp-server/tests/dns_rebinding_integration_test.rs
@@ -186,3 +186,56 @@ async fn configured_allowed_host_is_accepted_and_others_still_rejected() -> Resu
 
     Ok(())
 }
+
+/// Configuring an allowlist *replaces* the loopback default rather than adding to it,
+/// so a deployment that still needs local clients has to list loopback explicitly. This
+/// is easy to trip over, so it is pinned here rather than left to be discovered.
+#[tokio::test]
+async fn configured_allowlist_replaces_the_loopback_default() -> Result<()> {
+    const CONFIGURED_HOST: &str = "wassette.internal";
+
+    let port = find_open_port().await?;
+    let temp_dir = tempfile::tempdir()?;
+    let _server = spawn_server_with_args(
+        port,
+        temp_dir.path(),
+        &["--allowed-host".to_string(), CONFIGURED_HOST.to_string()],
+    )
+    .await?;
+    wait_until_listening(port).await?;
+
+    let loopback_host = format!("127.0.0.1:{port}");
+    let loopback_status = post_initialize_status(port, &loopback_host).await?;
+    assert_eq!(
+        loopback_status, 403,
+        "loopback Host `{loopback_host}` is rejected once an allowlist is configured, \
+         because the configured list replaces the default rather than extending it \
+         (got {loopback_status})"
+    );
+
+    // ...and listing loopback alongside the deployment name restores it.
+    let port = find_open_port().await?;
+    let temp_dir = tempfile::tempdir()?;
+    let _server = spawn_server_with_args(
+        port,
+        temp_dir.path(),
+        &[
+            "--allowed-host".to_string(),
+            CONFIGURED_HOST.to_string(),
+            "--allowed-host".to_string(),
+            "127.0.0.1".to_string(),
+        ],
+    )
+    .await?;
+    wait_until_listening(port).await?;
+
+    let loopback_host = format!("127.0.0.1:{port}");
+    let loopback_status = post_initialize_status(port, &loopback_host).await?;
+    assert_eq!(
+        loopback_status, 200,
+        "loopback Host `{loopback_host}` should be accepted when listed explicitly \
+         (got {loopback_status})"
+    );
+
+    Ok(())
+}

--- a/docs/deployment/operations.md
+++ b/docs/deployment/operations.md
@@ -272,6 +272,39 @@ If tools fail with permission errors:
 2. Check logs for specific permission denials
 3. Grant necessary permissions using `wassette permission grant` commands
 
+### MCP Requests Return 403
+
+If `/mcp` answers `403` while the server is plainly running and listening, the `Host`
+header is being rejected before MCP dispatch. By default only loopback values are
+accepted, as protection against DNS rebinding, so this is the expected result of
+addressing the server by a container name, service name or DNS name.
+
+Note that `/health`, `/ready` and `/info` sit outside `/mcp` and are not subject to this
+check, so they answer normally while `/mcp` refuses. A reachability probe against
+`/health` therefore proves the process is up and tells you nothing about whether MCP
+clients can connect.
+
+Add the name the clients actually use:
+
+```bash
+wassette serve --streamable-http --bind-address 0.0.0.0:9001 \
+  --allowed-host wassette.internal
+```
+
+Changing `--bind-address` alone does not help, as the bind address and the `Host`
+allowlist are independent. Confirm what clients are sending by comparing a request that
+works against one that does not:
+
+```bash
+# Accepted: loopback is allowed by default
+curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:9001/mcp \
+  -H 'Host: 127.0.0.1:9001'
+
+# Rejected with 403 unless wassette.internal is on the allowlist
+curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:9001/mcp \
+  -H 'Host: wassette.internal:9001'
+```
+
 ## Best Practices
 
 1. **Use INFO level in production** for a good balance between visibility and performance

--- a/docs/deployment/operations.md
+++ b/docs/deployment/operations.md
@@ -292,18 +292,37 @@ wassette serve --streamable-http --bind-address 0.0.0.0:9001 \
 ```
 
 Changing `--bind-address` alone does not help, as the bind address and the `Host`
-allowlist are independent. Confirm what clients are sending by comparing a request that
-works against one that does not:
+allowlist are independent.
+
+Note also that a configured allowlist **replaces** the loopback default rather than
+extending it. If `/mcp` started returning `403` for `localhost` right after you added
+`--allowed-host`, that is why: list loopback explicitly alongside the deployment name.
+
+Confirm what the server accepts by sending a real `initialize` request and comparing
+status codes:
 
 ```bash
-# Accepted: loopback is allowed by default
-curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:9001/mcp \
-  -H 'Host: 127.0.0.1:9001'
+BODY='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}'
 
-# Rejected with 403 unless wassette.internal is on the allowlist
+# 200: this Host is on the allowlist
 curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:9001/mcp \
-  -H 'Host: wassette.internal:9001'
+  -H 'Host: 127.0.0.1:9001' \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d "$BODY"
+
+# 403: this Host is not
+curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:9001/mcp \
+  -H 'Host: wassette.internal:9001' \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d "$BODY"
 ```
+
+The headers and body matter for reading the result. `403` always means the `Host` check
+rejected the request. Any other status means the `Host` was accepted and you are seeing
+the MCP layer respond, so a bare `curl -X POST` with no body returns `406` rather than
+`200` even when the `Host` is fine.
 
 ## Best Practices
 

--- a/docs/design/mcp-threat-model.md
+++ b/docs/design/mcp-threat-model.md
@@ -94,7 +94,9 @@ When Wassette runs as an HTTP server, it exposes the MCP management plane, inclu
 
 Wassette mitigates this attack through rmcp's `StreamableHttpService`, which rejects HTTP requests whose `Host` header is not a trusted loopback value before MCP processing begins. Streamable HTTP at `/mcp` is now the only supported HTTP transport because the removed SSE transport did not provide this validation. Operators exposing Wassette beyond loopback should place it behind an authenticating reverse proxy.
 
-A deployment addressed by a name other than `localhost`, such as a container or service name, must add that name to the allowlist with `--allowed-host`, `WASSETTE_ALLOWED_HOSTS`, or the `allowed_hosts` configuration key. This widens the check to exactly the names configured and no further: every other `Host` value is still rejected, so the protection above continues to hold. It does not replace the reverse proxy, because the allowlist authenticates nothing. It only decides which names the server will answer to, and Wassette still performs no authentication or authorization of its own on the HTTP transport.
+A deployment addressed by a name other than `localhost`, such as a container or service name, must configure that name with `--allowed-host`, `WASSETTE_ALLOWED_HOSTS`, or the `allowed_hosts` configuration key. A configured list **replaces** the loopback default rather than extending it, so a deployment that also serves local clients must list loopback explicitly. Every `Host` value outside the configured list is still rejected before MCP dispatch, so the protection above continues to hold for everything not named.
+
+This does not replace the reverse proxy, because the allowlist authenticates nothing. It only decides which names the server will answer to, and Wassette still performs no authentication or authorization of its own on the HTTP transport.
 
 ## Attack Consequences
 

--- a/docs/design/mcp-threat-model.md
+++ b/docs/design/mcp-threat-model.md
@@ -94,6 +94,8 @@ When Wassette runs as an HTTP server, it exposes the MCP management plane, inclu
 
 Wassette mitigates this attack through rmcp's `StreamableHttpService`, which rejects HTTP requests whose `Host` header is not a trusted loopback value before MCP processing begins. Streamable HTTP at `/mcp` is now the only supported HTTP transport because the removed SSE transport did not provide this validation. Operators exposing Wassette beyond loopback should place it behind an authenticating reverse proxy.
 
+A deployment addressed by a name other than `localhost`, such as a container or service name, must add that name to the allowlist with `--allowed-host`, `WASSETTE_ALLOWED_HOSTS`, or the `allowed_hosts` configuration key. This widens the check to exactly the names configured and no further: every other `Host` value is still rejected, so the protection above continues to hold. It does not replace the reverse proxy, because the allowlist authenticates nothing. It only decides which names the server will answer to, and Wassette still performs no authentication or authorization of its own on the HTTP transport.
+
 ## Attack Consequences
 
 The threat categories described above are root causes that can lead to various security consequences. Understanding these consequences helps in designing monitoring, incident response, and defense-in-depth strategies.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -97,15 +97,28 @@ wassette serve --streamable-http
 
 # Use a custom bind address
 wassette serve --bind-address 0.0.0.0:8080
+
+# Accept requests addressed by a name other than localhost
+wassette serve --streamable-http \
+  --bind-address 0.0.0.0:9001 \
+  --allowed-host wassette.internal
 ```
 
 **Options:**
 - `--streamable-http`: Explicitly select Streamable HTTP transport
 - `--bind-address <ADDRESS>`: Set the bind address (default: `127.0.0.1:9001`)
+- `--allowed-host <HOST>`: Accept this `Host` header value on `/mcp`. Repeat for several. Defaults to loopback only
 - `--component-dir <PATH>`: Set component storage directory (default: `$XDG_DATA_HOME/wassette/components`)
 - `--env <KEY=VALUE>`: Set environment variables (can be specified multiple times)
 - `--env-file <PATH>`: Load environment variables from a file
 - `--disable-builtin-tools`: Disable built-in tools (load-component, unload-component, etc.)
+
+**Note:** `--bind-address` and `--allowed-host` are independent. Binding to `0.0.0.0`
+makes the server reachable on every interface, but requests are still rejected with
+`403` before MCP dispatch unless their `Host` header is on the allowlist. That check
+defends against DNS rebinding, so a server addressed as `http://wassette:9001/mcp` needs
+`--allowed-host wassette` even though it is already listening. An entry without a port
+matches any port; an entry with one must match exactly.
 
 ## Component Management
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -120,6 +120,20 @@ defends against DNS rebinding, so a server addressed as `http://wassette:9001/mc
 `--allowed-host wassette` even though it is already listening. An entry without a port
 matches any port; an entry with one must match exactly.
 
+**A configured allowlist replaces the loopback default, it does not extend it.** After
+`--allowed-host wassette.internal`, requests with `Host: localhost` or `Host: 127.0.0.1`
+are rejected. Pass loopback explicitly if local clients must keep working:
+
+```bash
+wassette serve --streamable-http --bind-address 0.0.0.0:9001 \
+  --allowed-host wassette.internal \
+  --allowed-host localhost \
+  --allowed-host 127.0.0.1
+```
+
+The `/health`, `/ready` and `/info` endpoints sit outside `/mcp` and are not subject to
+this check, so health probes are unaffected either way.
+
 ## Component Management
 
 ### `wassette component load`

--- a/docs/reference/configuration-files.md
+++ b/docs/reference/configuration-files.md
@@ -63,10 +63,10 @@ DATABASE_URL = "postgresql://localhost/mydb"
 
 - **Type**: Array of strings
 - **Default**: Unset, which accepts loopback (`localhost`, `127.0.0.1`, `::1`) only
-- **Description**: `Host` header values accepted on the `/mcp` endpoint for Streamable HTTP. Requests whose `Host` is not listed are rejected with `403` before MCP dispatch, which is what prevents DNS rebinding against a locally running server. Set this when the server is addressed by a service name, container name or DNS name rather than by `localhost`. Entries may be a bare hostname, which matches any port, or `host:port`, which must match exactly. This setting is independent of `bind_address` and is ignored when using stdio transport.
+- **Description**: `Host` header values accepted on the `/mcp` endpoint for Streamable HTTP. Requests whose `Host` is not listed are rejected with `403` before MCP dispatch, which is what prevents DNS rebinding against a locally running server. Set this when the server is addressed by a service name, container name or DNS name rather than by `localhost`. Entries may be a bare hostname, which matches any port, or `host:port`, which must match exactly. A configured list **replaces** the loopback default rather than extending it, so include loopback explicitly if local clients must keep working. An empty list is treated as unset, leaving the loopback default in place. This setting is independent of `bind_address` and is ignored when using stdio transport.
 
 ```toml
-allowed_hosts = ["wassette.internal", "wassette.example.com:9001"]
+allowed_hosts = ["wassette.internal", "localhost", "127.0.0.1"]
 ```
 
 #### `environment_vars`

--- a/docs/reference/configuration-files.md
+++ b/docs/reference/configuration-files.md
@@ -59,6 +59,16 @@ DATABASE_URL = "postgresql://localhost/mydb"
 - **Default**: `127.0.0.1:9001`
 - **Description**: Bind address for Streamable HTTP. The address should be in the format `host:port`. Use `0.0.0.0` to bind to all network interfaces, or a specific IP address to bind to a particular interface. This setting is ignored when using stdio transport.
 
+#### `allowed_hosts`
+
+- **Type**: Array of strings
+- **Default**: Unset, which accepts loopback (`localhost`, `127.0.0.1`, `::1`) only
+- **Description**: `Host` header values accepted on the `/mcp` endpoint for Streamable HTTP. Requests whose `Host` is not listed are rejected with `403` before MCP dispatch, which is what prevents DNS rebinding against a locally running server. Set this when the server is addressed by a service name, container name or DNS name rather than by `localhost`. Entries may be a bare hostname, which matches any port, or `host:port`, which must match exactly. This setting is independent of `bind_address` and is ignored when using stdio transport.
+
+```toml
+allowed_hosts = ["wassette.internal", "wassette.example.com:9001"]
+```
+
 #### `environment_vars`
 
 - **Type**: Table/Map

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -57,6 +57,14 @@ the bind address: binding to `0.0.0.0` does not by itself make a server reachabl
 empty after trimming leaves the loopback default in place rather than disabling the
 check.
 
+A configured list **replaces** the loopback default rather than extending it, so include
+loopback explicitly if local clients must keep working:
+
+```bash
+WASSETTE_ALLOWED_HOSTS=wassette.internal,localhost,127.0.0.1 \
+  wassette serve --streamable-http --bind-address 0.0.0.0:9001
+```
+
 **Precedence:** CLI (`--allowed-host`) > `WASSETTE_ALLOWED_HOSTS` > Config file (`allowed_hosts`) > Default (loopback only)
 
 ## Component Environment Variables

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -53,9 +53,13 @@ Requests whose `Host` is not listed are rejected with `403` before MCP dispatch,
 is what prevents DNS rebinding against a locally running server. This is independent of
 the bind address: binding to `0.0.0.0` does not by itself make a server reachable as
 `http://wassette:9001/mcp`. Entries may be a bare hostname, which matches any port, or
-`host:port`, which must match exactly. Empty entries are ignored, and a value that is
-empty after trimming leaves the loopback default in place rather than disabling the
-check.
+`host:port`, which must match exactly.
+
+Empty entries are dropped, and a value that is empty after trimming is treated as if the
+variable were not set at all. It never disables the check. Note that "not set" means the
+next source down still applies: an `allowed_hosts` list in the config file continues to
+take effect, and the loopback default is used only when no lower-precedence value exists
+either.
 
 A configured list **replaces** the loopback default rather than extending it, so include
 loopback explicitly if local clients must keep working:

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -39,6 +39,26 @@ WASSETTE_CONFIG_FILE=/path/to/config.toml wassette serve
 
 Default: `$XDG_CONFIG_HOME/wassette/config.toml`
 
+### WASSETTE_ALLOWED_HOSTS
+Comma-separated `Host` header values accepted on the `/mcp` endpoint.
+
+```bash
+WASSETTE_ALLOWED_HOSTS=wassette.internal,wassette.example.com:9001 \
+  wassette serve --streamable-http --bind-address 0.0.0.0:9001
+```
+
+Default: unset, which accepts loopback (`localhost`, `127.0.0.1`, `::1`) only.
+
+Requests whose `Host` is not listed are rejected with `403` before MCP dispatch, which
+is what prevents DNS rebinding against a locally running server. This is independent of
+the bind address: binding to `0.0.0.0` does not by itself make a server reachable as
+`http://wassette:9001/mcp`. Entries may be a bare hostname, which matches any port, or
+`host:port`, which must match exactly. Empty entries are ignored, and a value that is
+empty after trimming leaves the loopback default in place rather than disabling the
+check.
+
+**Precedence:** CLI (`--allowed-host`) > `WASSETTE_ALLOWED_HOSTS` > Config file (`allowed_hosts`) > Default (loopback only)
+
 ## Component Environment Variables
 
 ### Quick Start


### PR DESCRIPTION
## Problem

`wassette serve` constructs `StreamableHttpService` with `Default::default()`. rmcp's
default `allowed_hosts` is `["localhost", "127.0.0.1", "::1"]`, validated before MCP
dispatch, so a server addressed by a service name, container name or DNS name is
rejected with `403` and there is no supported way to change it. Binding to `0.0.0.0`
does not help, because the bind address and the Host allowlist are independent.

The symptom is easy to misdiagnose: `/health`, `/ready` and `/info` sit outside the
`/mcp` subtree and answer normally while `/mcp` refuses.

## Change

Adds `--allowed-host` (repeatable), `WASSETTE_ALLOWED_HOSTS` (comma separated) and an
`allowed_hosts` key in `config.toml`, at precedence CLI > env > file > default.

When nothing is set the loopback default is unchanged, so no existing deployment is
affected.

## Notes for review

Two deliberate decisions, both worth a second opinion:

1. **A configured list replaces the loopback default rather than extending it**,
   following rmcp's `with_allowed_hosts` semantics. Deployments that also serve local
   clients must list loopback explicitly. This is documented and pinned by a test.
   Auto-appending loopback is a reasonable alternative if preferred.

2. **There is no way to disable Host validation.** rmcp treats an empty list as
   allow-all, so empty or whitespace-only values are ignored rather than propagated,
   leaving the loopback default in place. This keeps the protection added for
   GHSA-m873-hg53-85r5 unreachable through configuration.

The value is resolved outside figment because `admerge` concatenates sequences rather
than replacing them, which would combine a config file value with an environment value
instead of letting the higher-precedence source win.

## Tests

- Extends the existing Host validation integration test: a configured host is accepted,
  every other host is still rejected, and the original DNS rebinding case still passes
- Adds an integration test pinning the replace semantics, including loopback being
  accepted again when listed explicitly
- Adds config precedence unit tests: environment replacing a config file list, CLI
  replacing a config file list, comma splitting, and empty value handling

59 unit, 3 Host validation integration, 13 transport integration.
`cargo +nightly fmt --check` and `cargo clippy --all-targets` clean. No `CHANGELOG.md`
changes.

## Docs

CLI reference, environment variables, configuration files, the operations guide (a
troubleshooting entry for the `403`), and the threat model.
