### PR TITLE
Increase recursion limit for nightly coverage job compilation

### DIFF
--- a/crates/wassette-mcp-server/src/main.rs
+++ b/crates/wassette-mcp-server/src/main.rs
@@ -4,6 +4,11 @@
 //! The main `wassette(1)` command.
 
 #![warn(missing_docs)]
+// `call_tool` in `server.rs` boxes an async block whose `Send` obligation chain runs
+// through the whole tool-call path, and the next trait solver reports the resulting
+// depth as `recursion_depth_exceeding_limit`. The default limit of 128 is not enough
+// for that chain; see rust-lang/rust#159228.
+#![recursion_limit = "256"]
 
 use anyhow::{bail, Context, Result};
 use clap::{CommandFactory, Parser};

--- a/crates/wassette-mcp-server/tests/component_policy_integration_test.rs
+++ b/crates/wassette-mcp-server/tests/component_policy_integration_test.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+// `load_component`'s `Send` obligation chain exceeds the default recursion limit of
+// 128 under the next trait solver; see rust-lang/rust#159228.
+#![recursion_limit = "256"]
+
 use std::sync::Arc;
 use std::time::Duration;
 


### PR DESCRIPTION
The `test coverage` job has been failing with a compile error, not a test failure:

    error: overflow evaluating the requirement `Pin<Box<{async block@
    crates/wassette-mcp-server/src/server.rs:91:18: 91:28}>>: CoerceUnsized<...>`
    = note: `-D recursion-depth-exceeding-limit` implied by `-D warnings`

`recursion_depth_exceeding_limit` is a new future-incompatible lint that, in its own words, "detects trait solving overflow that only happens with the next solver". `call_tool` boxes an async block whose `Send` obligation chain runs through the whole tool-call path, and that chain is deeper than the default limit of 128 once the next solver evaluates it.

Nothing in the source changed to cause this. Coverage is the only job pinned to `toolchain: nightly`, and `setup-rust-toolchain` sets `-D warnings`, so the warning fails the job while `build` and `lint` stay green on stable 1.97.1. That also means this was going to turn main red on the next merge regardless of which pull request happened to land first.

`recursion_limit` is a crate-root attribute and every integration test file is its own crate, so two roots need it: the `wassette` binary, and `component_policy_integration_test`, whose `load_component` chain hits the same wall and only becomes visible once the binary compiles. A `--keep-going` sweep over the whole workspace confirms those are the only two.

Verified against 1.100.0-nightly (fb6531d55 2026-08-23), the nightly CI picked up, by A/B: at `recursion_limit = "32"` the test crate fails with three E0275 errors, and at 256 `cargo check --all-features --workspace --all-targets` is clean under `-D warnings`.

Raising the limit is preferred over allowing the lint workspace wide, because the note says it will become a hard error in a future release.