### PR TITLE
fix(install): stop reporting bash as an unsupported shell

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -223,7 +223,8 @@ if [[ "${CLEANUP_TEMP:-}" == "true" ]]; then
     rm -rf "$TEMP_DIR"
 fi
 
-# Function to add PATH to a file if not already present
+# Return codes: 0 = line appended, 1 = file absent / nothing done,
+# 2 = file exists and PATH is already configured
 add_path_to_file() {
     local file="$1"
     local path_line="export PATH=\"\$HOME/.local/bin:\$PATH\""
@@ -237,7 +238,7 @@ add_path_to_file() {
             return 0
         else
             print_warning "PATH already configured in $file"
-            return 1
+            return 2
         fi
     fi
     return 1
@@ -246,38 +247,52 @@ add_path_to_file() {
 # Track if we modified any files
 modified_files=()
 
-# Add to shell configuration files
+# Add to shell configuration files. shell_configured records whether PATH ends
+# up configured at all, whether we added the line or found it already there.
 shell_configured=false
+path_already_configured=false
+
+# Apply add_path_to_file to one candidate file and record the outcome.
+# Leaves that function's return code in PATH_FILE_STATUS for callers that
+# need to distinguish "already configured" from "file absent".
+configure_path_in() {
+    local file="$1"
+
+    PATH_FILE_STATUS=0
+    add_path_to_file "$file" || PATH_FILE_STATUS=$?
+
+    case "$PATH_FILE_STATUS" in
+        0)
+            modified_files+=("$file")
+            shell_configured=true
+            ;;
+        2)
+            path_already_configured=true
+            shell_configured=true
+            ;;
+    esac
+}
 
 # Check for bash
 if [[ -n "$BASH_VERSION" ]] || [[ "$SHELL" == */bash ]]; then
-    if add_path_to_file "$HOME/.bashrc"; then
-        modified_files+=("$HOME/.bashrc")
-        shell_configured=true
-    fi
-    
-    if add_path_to_file "$HOME/.bash_profile"; then
-        modified_files+=("$HOME/.bash_profile")
-        shell_configured=true
-    fi
+    configure_path_in "$HOME/.bashrc"
+    configure_path_in "$HOME/.bash_profile"
 fi
 
 # Check for zsh
 if [[ -n "$ZSH_VERSION" ]] || [[ "$SHELL" == */zsh ]]; then
-    if add_path_to_file "$HOME/.zshrc"; then
-        modified_files+=("$HOME/.zshrc")
-        shell_configured=true
-    fi
+    configure_path_in "$HOME/.zshrc"
 fi
 
-# Only add to .profile if no shell-specific config was added
+# Only fall back to .profile if no shell-specific config file was found
 if [[ "$shell_configured" == "false" ]]; then
-    if add_path_to_file "$HOME/.profile"; then
-        modified_files+=("$HOME/.profile")
+    configure_path_in "$HOME/.profile"
+
+    if [[ "$PATH_FILE_STATUS" -eq 0 ]]; then
         print_warning "Added PATH to .profile - you may need to start a new login session"
         print_warning "or run 'source ~/.profile' to use $BINARY_NAME immediately"
-    else
-        print_warning "Unsupported shell detected: $SHELL"
+    elif [[ "$PATH_FILE_STATUS" -eq 1 ]]; then
+        print_warning "No shell configuration file was found to update (SHELL: $SHELL)"
         print_warning "Please manually add '$INSTALL_DIR' to your PATH"
         print_warning "For most shells, add this line to your shell's config file:"
         print_warning "  export PATH=\"\$HOME/.local/bin:\$PATH\""
@@ -315,6 +330,8 @@ if [[ ${#modified_files[@]} -gt 0 ]]; then
     for file in "${modified_files[@]}"; do
         echo "    - $file"
     done
+elif [[ "$path_already_configured" == "true" ]]; then
+    print_status "PATH is already configured; no shell configuration files needed modification."
 else
     echo ""
     print_warning "No shell configuration files were modified."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -224,22 +224,30 @@ if [[ "${CLEANUP_TEMP:-}" == "true" ]]; then
 fi
 
 # Return codes: 0 = line appended, 1 = file absent / nothing done,
-# 2 = file exists and PATH is already configured
+# 2 = file exists and PATH is already configured, 3 = append failed
 add_path_to_file() {
     local file="$1"
     local path_line="export PATH=\"\$HOME/.local/bin:\$PATH\""
-    
+    # Match a PATH assignment that mentions .local/bin, so that a commented-out
+    # line or an unrelated variable such as MYPATH does not count as configured.
+    # Case-insensitive so that zsh's array form, path=(~/.local/bin $path), does.
+    local path_pattern='^[[:space:]]*(export[[:space:]]+)?path=.*\.local/bin'
+
     if [[ -f "$file" ]]; then
-        if ! grep -q "\.local/bin" "$file"; then
-            print_status "Adding PATH to $file"
-            echo "" >> "$file"
-            echo "# Added by binary installer script" >> "$file"
-            echo "$path_line" >> "$file"
-            return 0
-        else
-            print_warning "PATH already configured in $file"
+        if grep -qiE "$path_pattern" "$file"; then
+            print_status "PATH already configured in $file"
             return 2
         fi
+
+        print_status "Adding PATH to $file"
+        # One simple command, so that a failed redirection is reported. Bash
+        # returns 0 when the redirection on a *group* command fails, which
+        # would hide the error.
+        if ! printf '\n%s\n%s\n' "# Added by binary installer script" "$path_line" >> "$file"; then
+            print_error "Failed to write PATH to $file"
+            return 3
+        fi
+        return 0
     fi
     return 1
 }
@@ -252,9 +260,11 @@ modified_files=()
 shell_configured=false
 path_already_configured=false
 
-# Apply add_path_to_file to one candidate file and record the outcome.
+# Apply add_path_to_file to one candidate file and record the outcome. Only
+# "appended" and "already configured" count as configured; a missing file or a
+# failed write leave shell_configured alone so the next candidate is tried.
 # Leaves that function's return code in PATH_FILE_STATUS for callers that
-# need to distinguish "already configured" from "file absent".
+# need to tell those outcomes apart.
 configure_path_in() {
     local file="$1"
 
@@ -288,15 +298,22 @@ fi
 if [[ "$shell_configured" == "false" ]]; then
     configure_path_in "$HOME/.profile"
 
-    if [[ "$PATH_FILE_STATUS" -eq 0 ]]; then
-        print_warning "Added PATH to .profile - you may need to start a new login session"
-        print_warning "or run 'source ~/.profile' to use $BINARY_NAME immediately"
-    elif [[ "$PATH_FILE_STATUS" -eq 1 ]]; then
-        print_warning "No shell configuration file was found to update (SHELL: $SHELL)"
-        print_warning "Please manually add '$INSTALL_DIR' to your PATH"
-        print_warning "For most shells, add this line to your shell's config file:"
-        print_warning "  export PATH=\"\$HOME/.local/bin:\$PATH\""
-    fi
+    case "$PATH_FILE_STATUS" in
+        0)
+            print_warning "Added PATH to .profile - you may need to start a new login session"
+            print_warning "or run 'source ~/.profile' to use $BINARY_NAME immediately"
+            ;;
+        2)
+            ;;
+        *)
+            if [[ "$PATH_FILE_STATUS" -eq 1 ]]; then
+                print_warning "No shell configuration file could be updated (SHELL: $SHELL)"
+            fi
+            print_warning "Please manually add '$INSTALL_DIR' to your PATH"
+            print_warning "For most shells, add this line to your shell's config file:"
+            print_warning "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+            ;;
+    esac
 fi
 
 # Update current session's PATH


### PR DESCRIPTION
add_path_to_file returned 1 for two different outcomes: the file does not exist, and the file exists with PATH already configured. Callers treated only a fresh append as success, so a user whose .bashrc already had ~/.local/bin left shell_configured false, fell through to the .profile fallback, and was told "Unsupported shell detected: /bin/bash" plus instructions to edit files that needed no editing. The summary then warned that no files were modified, contradicting the "wassette is now available in PATH" line printed two lines above.

Give the function a third return code for "already configured" and treat it as success, so the fallback only runs when no shell configuration file was found at all. The manual-PATH advice now reports that no configuration file was found, and includes $SHELL, rather than calling the user's shell unsupported. The summary reports an already-configured PATH as a normal outcome instead of a warning.

The repeated call sites are folded into a configure_path_in helper so the three-outcome handling is written once.