### PR TITLE
refactor(ci): extract the release build matrix into a reusable workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,99 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      ref:
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux targets
+          - target: x86_64-unknown-linux-gnu
+            name: wassette
+            arch: linux_amd64
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            name: wassette
+            arch: linux_arm64
+            runner: ubuntu-24.04-arm
+          # macOS targets
+          - target: x86_64-apple-darwin
+            name: wassette
+            arch: darwin_amd64
+            runner: macos-15-intel
+          - target: aarch64-apple-darwin
+            name: wassette
+            arch: darwin_arm64
+            runner: macos-latest
+          # Windows targets
+          - target: x86_64-pc-windows-msvc
+            name: wassette
+            arch: windows_amd64
+            runner: windows-latest
+          - target: aarch64-pc-windows-msvc
+            name: wassette
+            arch: windows_arm64
+            runner: windows-11-arm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Sccache Action
+        if: matrix.target != 'x86_64-apple-darwin'
+        uses: Mozilla-Actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          target: ${{ matrix.target }}
+
+      - name: Add WASM target
+        run: rustup target add wasm32-wasip2
+
+      - name: Build release binary
+        run: cargo build --release
+        env:
+          SCCACHE_GHA_ENABLED: ${{ matrix.target != 'x86_64-apple-darwin' && 'true' || 'false' }}
+          RUSTC_WRAPPER: ${{ matrix.target != 'x86_64-apple-darwin' && 'sccache' || '' }}
+
+      - name: Prepare binary (Unix)
+        if: "!contains(matrix.target, 'windows')"
+        run: |
+          cd target/release
+          tar czvf ../../${{ matrix.name }}_${{ inputs.version }}_${{ matrix.arch }}.tar.gz wassette
+          cd -
+
+      - name: Prepare binary (Windows)
+        if: contains(matrix.target, 'windows')
+        run: |
+          cd target/release
+          7z a ../../${{ matrix.name }}_${{ inputs.version }}_${{ matrix.arch }}.zip wassette.exe
+          cd -
+        shell: bash
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.name }}-${{ matrix.arch }}
+          path: |
+            ${{ matrix.name }}_*_${{ matrix.arch }}.tar.gz
+            ${{ matrix.name }}_*_${{ matrix.arch }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,110 +48,11 @@ jobs:
           fi
 
   build:
-    name: Build ${{ matrix.target }}
+    name: Build
     needs: validate-release
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Linux targets
-          - target: x86_64-unknown-linux-gnu
-            name: wassette
-            arch: linux_amd64
-            runner: ubuntu-latest
-          - target: aarch64-unknown-linux-gnu
-            name: wassette
-            arch: linux_arm64
-            runner: ubuntu-24.04-arm
-          # macOS targets
-          - target: x86_64-apple-darwin
-            name: wassette
-            arch: darwin_amd64
-            runner: macos-15-intel
-          - target: aarch64-apple-darwin
-            name: wassette
-            arch: darwin_arm64
-            runner: macos-latest
-          # Windows targets
-          - target: x86_64-pc-windows-msvc
-            name: wassette
-            arch: windows_amd64
-            runner: windows-latest
-          - target: aarch64-pc-windows-msvc
-            name: wassette
-            arch: windows_arm64
-            runner: windows-11-arm
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Sccache Action
-        if: matrix.target != 'x86_64-apple-darwin'
-        uses: Mozilla-Actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
-
-      - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-        with:
-          target: ${{ matrix.target }}
-
-      - name: Add WASM target
-        run: rustup target add wasm32-wasip2
-
-      - name: Build release binary
-        run: cargo build --release
-        env:
-          SCCACHE_GHA_ENABLED: ${{ matrix.target != 'x86_64-apple-darwin' && 'true' || 'false' }}
-          RUSTC_WRAPPER: ${{ matrix.target != 'x86_64-apple-darwin' && 'sccache' || '' }}
-
-      - name: Extract version (Unix)
-        if: "!contains(matrix.target, 'windows')"
-        id: version-unix
-        run: |
-          VERSION="${RELEASE_TAG#v}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Extract version (Windows)
-        if: contains(matrix.target, 'windows')
-        id: version-windows
-        run: |
-          $VERSION = "${{ env.RELEASE_TAG }}" -replace '^v', ''
-          echo "version=$VERSION" >> $env:GITHUB_OUTPUT
-        shell: pwsh
-
-      - name: Set version output
-        id: version
-        run: |
-          if [[ "${{ matrix.target }}" == *"windows"* ]]; then
-            echo "version=${{ steps.version-windows.outputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=${{ steps.version-unix.outputs.version }}" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-
-      - name: Prepare binary (Unix)
-        if: "!contains(matrix.target, 'windows')"
-        run: |
-          cd target/release
-          tar czvf ../../${{ matrix.name }}_${{ steps.version.outputs.version }}_${{ matrix.arch }}.tar.gz wassette
-          cd -
-
-      - name: Prepare binary (Windows)
-        if: contains(matrix.target, 'windows')
-        run: |
-          cd target/release
-          7z a ../../${{ matrix.name }}_${{ steps.version.outputs.version }}_${{ matrix.arch }}.zip wassette.exe
-          cd -
-        shell: bash
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ matrix.name }}-${{ matrix.arch }}
-          path: |
-            ${{ matrix.name }}_*_${{ matrix.arch }}.tar.gz
-            ${{ matrix.name }}_*_${{ matrix.arch }}.zip
+    uses: ./.github/workflows/build.yml
+    with:
+      version: ${{ github.event.inputs.version }}
 
   release:
     name: Create Release


### PR DESCRIPTION
## What

Moves the six-target build matrix out of `release.yml` into a new
`.github/workflows/build.yml` that runs `on: workflow_call`. The `build` job in `release.yml`
becomes a three-line call to it.

Nothing about the release pipeline changes: same six targets, same runners, same pinned action
SHAs, same sccache conditions, same artifact names and paths, and identical archive filenames.
`validate-release`, the `release` job and the three post-release dispatch jobs are untouched.

## Why

I would like to add a workflow that builds the same six targets from an arbitrary commit and
publishes them as a prerelease channel. The matrix is the expensive and fiddly part, six targets
across six runner types, and having a second copy of it that can drift from this one seems worth
avoiding.

This PR is only the extraction. It is deliberately separate so that if a release breaks, the
cause is unambiguous. The channel workflow follows in a second PR, on top of a build workflow
already known good.

## The one change that is not cosmetic

The build job's three version-extraction steps ("Extract version (Unix)", "Extract version
(Windows)", "Set version output") are deleted, and `steps.version.outputs.version` becomes
`inputs.version`.

Those steps existed only to strip the `v` prefix off `RELEASE_TAG`, which is a workflow-level
`env` in `release.yml`. **Workflow-level `env` does not propagate across a `workflow_call`
boundary**, so a build job that still read `RELEASE_TAG` would have produced archives named
`wassette__linux_amd64.tar.gz` with an empty version slot, and it would have done so silently.
Passing the version as an input removes the failure mode along with the three steps, and it
gives the future channel workflow the hook it needs to stamp a short commit SHA instead.

The caller passes the bare version, no `v` prefix, which is exactly what the archive names use
today.

## Two things worth a maintainer's eye

**Check names change shape.** The per-target checks were `Build x86_64-unknown-linux-gnu` and
now render as `Build / Build x86_64-unknown-linux-gnu`. `release.yml` is `workflow_dispatch`-only
and I could not find any branch protection or automation referencing the old names, but you can
see the repository settings and I cannot.

**Permissions.** `build.yml` declares `contents: read` and `actions: write`. The write on
`actions` is what the sccache GitHub Actions cache backend needs, and both are a subset of the
`actions: write` plus `contents: write` that `release.yml` already grants at workflow level, which
is the constraint a called workflow has to satisfy.

## How this was verified

- `actionlint` passes on `build.yml`, `release.yml` and the rest of the workflow directory.
- Both files parse as YAML.
- No reference to `RELEASE_TAG` or `steps.version` survives in `build.yml`.
- The extracted steps were diffed against the originals line by line. The only differences are
  the ones described above.

Not verified: an actual release has not been cut through the refactored pipeline. That is the
check that matters most and it needs a maintainer, so I would suggest cutting a throwaway
`-test` prerelease through it before this is relied on.