### PR TITLE
feat(ci): add a latest channel of on-demand prereleases built from any commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,99 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      ref:
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux targets
+          - target: x86_64-unknown-linux-gnu
+            name: wassette
+            arch: linux_amd64
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            name: wassette
+            arch: linux_arm64
+            runner: ubuntu-24.04-arm
+          # macOS targets
+          - target: x86_64-apple-darwin
+            name: wassette
+            arch: darwin_amd64
+            runner: macos-15-intel
+          - target: aarch64-apple-darwin
+            name: wassette
+            arch: darwin_arm64
+            runner: macos-latest
+          # Windows targets
+          - target: x86_64-pc-windows-msvc
+            name: wassette
+            arch: windows_amd64
+            runner: windows-latest
+          - target: aarch64-pc-windows-msvc
+            name: wassette
+            arch: windows_arm64
+            runner: windows-11-arm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Sccache Action
+        if: matrix.target != 'x86_64-apple-darwin'
+        uses: Mozilla-Actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          target: ${{ matrix.target }}
+
+      - name: Add WASM target
+        run: rustup target add wasm32-wasip2
+
+      - name: Build release binary
+        run: cargo build --release
+        env:
+          SCCACHE_GHA_ENABLED: ${{ matrix.target != 'x86_64-apple-darwin' && 'true' || 'false' }}
+          RUSTC_WRAPPER: ${{ matrix.target != 'x86_64-apple-darwin' && 'sccache' || '' }}
+
+      - name: Prepare binary (Unix)
+        if: "!contains(matrix.target, 'windows')"
+        run: |
+          cd target/release
+          tar czvf ../../${{ matrix.name }}_${{ inputs.version }}_${{ matrix.arch }}.tar.gz wassette
+          cd -
+
+      - name: Prepare binary (Windows)
+        if: contains(matrix.target, 'windows')
+        run: |
+          cd target/release
+          7z a ../../${{ matrix.name }}_${{ inputs.version }}_${{ matrix.arch }}.zip wassette.exe
+          cd -
+        shell: bash
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.name }}-${{ matrix.arch }}
+          path: |
+            ${{ matrix.name }}_*_${{ matrix.arch }}.tar.gz
+            ${{ matrix.name }}_*_${{ matrix.arch }}.zip

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -1,0 +1,171 @@
+name: Latest channel
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Commit or branch to build'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  actions: write
+  contents: write
+
+jobs:
+  prepare:
+    name: Prepare latest build
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.metadata.outputs.sha }}
+      short_sha: ${{ steps.metadata.outputs.short_sha }}
+      tag: ${{ steps.metadata.outputs.tag }}
+      title: ${{ steps.metadata.outputs.title }}
+      built_at: ${{ steps.metadata.outputs.built_at }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Resolve build metadata
+        id: metadata
+        run: |
+          SHA=$(git rev-parse HEAD)
+          SHORT_SHA=${SHA:0:7}
+          BUILT_AT=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          TAG_DATE=$(date -u --date="$BUILT_AT" +'%Y%m%d')
+          TAG_TIME=$(date -u --date="$BUILT_AT" +'%H%M')
+          TITLE_DATE=$(date -u --date="$BUILT_AT" +'%Y-%m-%d %H:%M')
+
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "tag=latest-$TAG_DATE-$TAG_TIME-$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "title=latest — $TITLE_DATE UTC ($SHORT_SHA)" >> "$GITHUB_OUTPUT"
+          echo "built_at=$BUILT_AT" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build
+    needs: prepare
+    uses: ./.github/workflows/build.yml
+    with:
+      version: ${{ needs.prepare.outputs.short_sha }}
+      ref: ${{ needs.prepare.outputs.sha }}
+
+  publish:
+    name: Publish latest build
+    runs-on: ubuntu-latest
+    needs: [prepare, build]
+    env:
+      SHA: ${{ needs.prepare.outputs.sha }}
+      SHORT_SHA: ${{ needs.prepare.outputs.short_sha }}
+      TAG: ${{ needs.prepare.outputs.tag }}
+      TITLE: ${{ needs.prepare.outputs.title }}
+      BUILT_AT: ${{ needs.prepare.outputs.built_at }}
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release-assets
+          find artifacts -name "*.tar.gz" -exec cp {} release-assets/ \;
+          find artifacts -name "*.zip" -exec cp {} release-assets/ \;
+          ls -la release-assets/
+
+      - name: Prepare release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          STABLE_TAG=$(gh api "/repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name')
+          COMPARE_URL="https://github.com/$GITHUB_REPOSITORY/compare/$STABLE_TAG...$SHA"
+
+          cat > release-notes.md <<EOF
+          Built from commit [\`$SHA\`](https://github.com/$GITHUB_REPOSITORY/commit/$SHA).
+
+          Built at \`$BUILT_AT\`.
+
+          [Compare with the most recent stable release ($STABLE_TAG)]($COMPARE_URL).
+
+          These builds are unsigned, built from an arbitrary commit, and covered by no release promise.
+          EOF
+
+      - name: Create draft, upload assets, and publish prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXPECTED_ASSETS=(
+            "wassette_${SHORT_SHA}_linux_amd64.tar.gz"
+            "wassette_${SHORT_SHA}_linux_arm64.tar.gz"
+            "wassette_${SHORT_SHA}_darwin_amd64.tar.gz"
+            "wassette_${SHORT_SHA}_darwin_arm64.tar.gz"
+            "wassette_${SHORT_SHA}_windows_amd64.zip"
+            "wassette_${SHORT_SHA}_windows_arm64.zip"
+          )
+          mapfile -t FOUND_ASSETS < <(find release-assets -maxdepth 1 -type f | sort)
+          if [ "${#FOUND_ASSETS[@]}" -ne "${#EXPECTED_ASSETS[@]}" ]; then
+            echo "::error::Expected ${#EXPECTED_ASSETS[@]} release assets, found ${#FOUND_ASSETS[@]}"
+            exit 1
+          fi
+
+          ASSETS=()
+          for NAME in "${EXPECTED_ASSETS[@]}"; do
+            ASSET="release-assets/$NAME"
+            if [ ! -f "$ASSET" ]; then
+              echo "::error::Missing expected release asset $NAME"
+              exit 1
+            fi
+            ASSETS+=("$ASSET")
+          done
+
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft \
+            --prerelease \
+            --target "$SHA" \
+            --title "$TITLE" \
+            --notes-file release-notes.md
+
+          gh release upload "$TAG" "${ASSETS[@]}" \
+            --repo "$GITHUB_REPOSITORY"
+
+          UPLOADED_ASSETS=$(gh release view "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json assets \
+            --jq '.assets[].name')
+          for ASSET in "${ASSETS[@]}"; do
+            NAME=$(basename "$ASSET")
+            if ! grep -Fxq "$NAME" <<< "$UPLOADED_ASSETS"; then
+              echo "::error::Draft release is missing asset $NAME"
+              exit 1
+            fi
+          done
+
+          gh release edit "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft=false \
+            --prerelease
+
+      - name: Prune old latest prereleases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mapfile -t OLD_TAGS < <(
+            gh release list \
+              --repo "$GITHUB_REPOSITORY" \
+              --limit 100 \
+              --json tagName,createdAt,isPrerelease \
+              --jq '[.[] | select(.isPrerelease and (.tagName | startswith("latest-")))] | sort_by(.createdAt) | reverse | .[5:] | .[].tagName'
+          )
+
+          for OLD_TAG in "${OLD_TAGS[@]}"; do
+            gh release delete "$OLD_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --cleanup-tag \
+              --yes
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,110 +48,11 @@ jobs:
           fi
 
   build:
-    name: Build ${{ matrix.target }}
+    name: Build
     needs: validate-release
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Linux targets
-          - target: x86_64-unknown-linux-gnu
-            name: wassette
-            arch: linux_amd64
-            runner: ubuntu-latest
-          - target: aarch64-unknown-linux-gnu
-            name: wassette
-            arch: linux_arm64
-            runner: ubuntu-24.04-arm
-          # macOS targets
-          - target: x86_64-apple-darwin
-            name: wassette
-            arch: darwin_amd64
-            runner: macos-15-intel
-          - target: aarch64-apple-darwin
-            name: wassette
-            arch: darwin_arm64
-            runner: macos-latest
-          # Windows targets
-          - target: x86_64-pc-windows-msvc
-            name: wassette
-            arch: windows_amd64
-            runner: windows-latest
-          - target: aarch64-pc-windows-msvc
-            name: wassette
-            arch: windows_arm64
-            runner: windows-11-arm
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Sccache Action
-        if: matrix.target != 'x86_64-apple-darwin'
-        uses: Mozilla-Actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
-
-      - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-        with:
-          target: ${{ matrix.target }}
-
-      - name: Add WASM target
-        run: rustup target add wasm32-wasip2
-
-      - name: Build release binary
-        run: cargo build --release
-        env:
-          SCCACHE_GHA_ENABLED: ${{ matrix.target != 'x86_64-apple-darwin' && 'true' || 'false' }}
-          RUSTC_WRAPPER: ${{ matrix.target != 'x86_64-apple-darwin' && 'sccache' || '' }}
-
-      - name: Extract version (Unix)
-        if: "!contains(matrix.target, 'windows')"
-        id: version-unix
-        run: |
-          VERSION="${RELEASE_TAG#v}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Extract version (Windows)
-        if: contains(matrix.target, 'windows')
-        id: version-windows
-        run: |
-          $VERSION = "${{ env.RELEASE_TAG }}" -replace '^v', ''
-          echo "version=$VERSION" >> $env:GITHUB_OUTPUT
-        shell: pwsh
-
-      - name: Set version output
-        id: version
-        run: |
-          if [[ "${{ matrix.target }}" == *"windows"* ]]; then
-            echo "version=${{ steps.version-windows.outputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=${{ steps.version-unix.outputs.version }}" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-
-      - name: Prepare binary (Unix)
-        if: "!contains(matrix.target, 'windows')"
-        run: |
-          cd target/release
-          tar czvf ../../${{ matrix.name }}_${{ steps.version.outputs.version }}_${{ matrix.arch }}.tar.gz wassette
-          cd -
-
-      - name: Prepare binary (Windows)
-        if: contains(matrix.target, 'windows')
-        run: |
-          cd target/release
-          7z a ../../${{ matrix.name }}_${{ steps.version.outputs.version }}_${{ matrix.arch }}.zip wassette.exe
-          cd -
-        shell: bash
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ matrix.name }}-${{ matrix.arch }}
-          path: |
-            ${{ matrix.name }}_*_${{ matrix.arch }}.tar.gz
-            ${{ matrix.name }}_*_${{ matrix.arch }}.zip
+    uses: ./.github/workflows/build.yml
+    with:
+      version: ${{ github.event.inputs.version }}
 
   release:
     name: Create Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 dependencies = [
+ "chrono",
  "git2",
 ]
 

--- a/crates/wassette-mcp-server/Cargo.toml
+++ b/crates/wassette-mcp-server/Cargo.toml
@@ -34,7 +34,7 @@ name = "wassette"
 path = "src/main.rs"
 
 [build-dependencies]
-built = { version = "0.8", features = ["git2"] }
+built = { version = "0.8", features = ["git2", "chrono"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/wassette-mcp-server/src/utils.rs
+++ b/crates/wassette-mcp-server/src/utils.rs
@@ -112,14 +112,15 @@ pub fn format_build_info() -> String {
     };
 
     format!(
-        "{} version.BuildInfo{{RustVersion:\"{}\", BuildProfile:\"{}\", BuildStatus:\"{}\", GitTag:\"{}\", Version:\"{}\", GitRevision:\"{}\"}}",
+        "{} version.BuildInfo{{RustVersion:\"{}\", BuildProfile:\"{}\", BuildStatus:\"{}\", GitTag:\"{}\", Version:\"{}\", GitRevision:\"{}\", BuildTime:\"{}\"}}",
         built_info::PKG_VERSION,
         rust_version,
         build_profile,
         build_status,
         git_tag,
         version,
-        git_revision
+        git_revision,
+        built_info::BUILT_TIME_UTC
     )
 }
 
@@ -139,6 +140,7 @@ mod tests {
         assert!(version_info.contains("GitTag"));
         assert!(version_info.contains("Version"));
         assert!(version_info.contains("GitRevision"));
+        assert!(version_info.contains("BuildTime"));
     }
 
     #[test]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -125,6 +125,16 @@ This provides a reproducible environment for using and developing Wassette.
 {{#endtab }}
 {{#endtabs }}
 
+## Latest Development Channel
+
+The `latest` channel resolves the install script to the newest on-demand development build instead of the latest stable release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/microsoft/wassette/main/scripts/install.sh | WASSETTE_CHANNEL=latest bash
+```
+
+These builds are unsigned and may come from an arbitrary commit selected on `main` or another ref. Only the newest five builds are retained, and they are covered by no release promise. The channel provides stable resolution, not a stable download URL; the resolved URL changes with every build.
+
 ## Homebrew Tap (Alternative)
 
 `brew install wassette` installs from `homebrew/core` and is the recommended path on both macOS and Linux. This repository also maintains its own formula, which you can use if you need a version that is not yet in `homebrew/core`:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -102,6 +102,36 @@ get_latest_release_info() {
         print_error "curl is required but not installed. Please install curl."
         exit 1
     fi
+
+    if [[ "${WASSETTE_CHANNEL:-}" == "latest" ]]; then
+        local api_response
+        api_response=$(curl -s "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=100")
+
+        if [[ -z "$api_response" ]]; then
+            print_error "Failed to fetch latest channel information from GitHub API"
+            exit 1
+        fi
+
+        local tag_name
+        tag_name=$(echo "$api_response" \
+            | sed -n 's/.*"tag_name": *"\(latest-[^"]*\)".*/\1/p' | sort | tail -1)
+
+        if [[ -z "$tag_name" ]]; then
+            print_error "No latest channel release was found"
+            exit 1
+        fi
+
+        local version="${tag_name##*-}"
+
+        print_status "Latest version: $tag_name"
+        print_warning "The latest channel is an unsigned development build."
+
+        BINARY_ARCHIVE="${BINARY_NAME}_${version}_${PLATFORM}.tar.gz"
+        DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${tag_name}/${BINARY_ARCHIVE}"
+
+        print_status "Download URL: $DOWNLOAD_URL"
+        return
+    fi
     
     local api_response
     api_response=$(curl -s "$BASE_URL")


### PR DESCRIPTION
> Stacked on #768 (`refactor/reusable-build-workflow`). The diff below includes that PR's commit
> until it merges, after which I will rebase. Review the second commit only.

## What

A `latest` channel: an on-demand build of any commit, published as a prerelease through the
release pipeline that already exists, with the newest five kept and older ones pruned.

The use cases are testing a fix before it ships, reproducing a bug against `main` rather than
against the last release, and running integration tests against current `main` instead of a
release that may be weeks old.

The governing constraint I set myself was **no new infrastructure**: no second repository, no
object storage, no registry client in the install path.

| | |
| --- | --- |
| Tag | `latest-<UTC date>-<UTC time>-<short sha>`, e.g. `latest-20260825-1430-a1b2c3d` |
| Marked | `prerelease: true` |
| Assets | short SHA in the version slot, `wassette_a1b2c3d_linux_amd64.tar.gz` |
| Trigger | `workflow_dispatch` only, with an optional ref input |
| Retention | newest five kept, older deleted with their tags |

## This does not fight immutable releases

A rolling channel usually implies a moving tag, and immutable releases forbids exactly that, so
it is worth being explicit.

Immutability forbids **moving or reusing** a tag. It does not forbid creating many tags, and it
does not forbid deleting a release. Every build here gets its own tag carrying its own SHA, so
nothing is ever moved and no name is ever reused. The constraint is never engaged.

The tag carries **time as well as date** for this reason: two dispatches against one commit on
one day would otherwise collide on a tag name, and under immutability that is unrecoverable
rather than merely annoying.

## Prerelease, not draft

Draft is not viable. Draft assets are not publicly downloadable and the git tag is not created
until publish, so a draft channel is one nobody can install from.

Prerelease has exactly the property this needs. `/releases/latest` returns the most recent
**non-prerelease, non-draft** release, so marking these `prerelease: true` means `install.sh`
today, and every existing consumer, keeps resolving to the newest stable release. **A channel
build cannot shadow a stable release by accident, ever.** Opting in has to be explicit, which is
the right default for unsigned builds off `main`.

## What is in the diff

**`.github/workflows/latest.yml`.** Three jobs: resolve the commit and compute the tag, call
`build.yml` with the short SHA as the version, then publish and prune.

The publish step reuses `release.yml`'s create-draft, upload, then publish sequence rather than a
single `gh release create` with assets. That ordering is what makes it immutability-safe: every
asset is attached before the release becomes immutable. It also keeps the existing
"expected six assets, fail if any is missing" check.

`prepare` resolves the input ref to a **full SHA** and every later job takes that, not the ref.
Passing a branch name down would let `main` move mid-run and produce six binaries from up to six
different commits under one tag.

Pruning uses `gh release delete --cleanup-tag`. Without `--cleanup-tag` the releases go and the
tags accumulate forever. It sorts explicitly on `createdAt` rather than trusting the order
`gh release list` returns, since the REST docs specify an ordering for `/releases/latest` but not
for `/releases`.

**`scripts/install.sh`.** Adds `WASSETTE_CHANNEL=latest`. Unset, or set to anything else, and the
resolution path is byte-for-byte what it is today.

The script has only `curl` and `sed`, and this change adds no dependency on `jq` or `gh`. The tag
format is fixed width by construction, so lexicographic order is chronological order and a
`sed`-and-`sort` pipeline resolves the newest channel tag correctly. The short SHA is the last
hyphen-separated field of the tag, which feeds the existing `BINARY_ARCHIVE` line unchanged. That
is why the SHA goes in the version slot rather than dropping the version from asset filenames:
version-free names would have meant changing both how the installer resolves a tag and how it
names an asset, where this changes only the first.

**Build time in `--version`.** `format_build_info()` already reports the commit through the
`built` crate, so the commit half of provenance is in place. This enables `built`'s `chrono`
feature and adds a `BuildTime` field, so a bug report against a channel build carries both the
commit and when it was built.

I did **not** remove the leading package version from that output, even though a channel build is
not `0.6.0` and reporting it is arguably wrong. `test_version_contains_cargo_version` asserts it
is present specifically to keep the Homebrew formula test passing, so removing it is a separate
decision with a blast radius beyond this PR. Happy to do it if you want it.

**`docs/installation.md`.** Documents the channel and says plainly that these builds are unsigned,
come from an arbitrary commit, are retained five deep, and are covered by no release promise.

## The trade-off, stated plainly

**There is no stable download URL.** The asset URL contains the tag and the tag changes every
build. What is stable is *resolution*: one API call finds the current build. That is the price of
not standing up another system, which was the trade I deliberately chose. If a genuinely stable
URL turns out to be a requirement, object storage behind a fixed URL is the option to reopen, and
it is the only one of the alternatives that provides it.

Also worth a conscious decision rather than a surprise: GitHub's own **"Latest" badge** on the
releases page will sit on the newest *stable* release while these are tagged `latest-*`. That is
correct behaviour and mildly confusing to look at.

## How this was verified

- `actionlint` passes on `latest.yml`, `build.yml` and `release.yml`.
- `bash -n scripts/install.sh` passes.
- The resolution pipeline was run against a fixture holding three out-of-order `latest-*` tags
  plus `v0.6.0` and `v0.5.0`. It returns the newest channel tag and never a stable one.
- `cargo test -p wassette-mcp-server --bins` passes, 72 tests, including the extended version
  assertions. A locally built binary reports
  `GitRevision:"57218a95..."` alongside `BuildTime:"Tue, 25 Aug 2026 18:04:44 +0000"`.

Not verified, and it needs a maintainer to dispatch it: **no channel build has actually been
published.** The publish and prune paths are statically checked only. The things I would want to
see on a first real dispatch are that six assets land, that `/releases/latest` still answers with
the stable release afterwards, that a second dispatch against the same commit produces a distinct
tag, and that a sixth dispatch leaves exactly five channel releases with the pruned tags gone.

One known rough edge: the release notes step calls `/releases/latest` to build a compare link, so
it would fail on a repository with no stable release yet. Not a case that applies here, but easy
to guard if you would rather it were.