### PR TITLE
fix(server): gracefully handle SIGTERM shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5090,6 +5090,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-test",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "tracing-test",

--- a/crates/wassette-mcp-server/Cargo.toml
+++ b/crates/wassette-mcp-server/Cargo.toml
@@ -26,6 +26,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/crates/wassette-mcp-server/src/main.rs
+++ b/crates/wassette-mcp-server/src/main.rs
@@ -21,6 +21,7 @@ use rmcp::transport::stdio as stdio_transport;
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 use serde_json::{json, Map};
+use tokio_util::sync::CancellationToken;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
 
@@ -47,38 +48,58 @@ use tools::ToolName;
 use utils::{format_build_info, load_component_registry, parse_env_var};
 
 #[cfg(unix)]
-async fn shutdown_signal() {
-    use tokio::signal::unix::{signal, SignalKind};
+struct ShutdownSignals {
+    sigint: tokio::signal::unix::Signal,
+    sigterm: tokio::signal::unix::Signal,
+}
 
-    let mut sigterm = match signal(SignalKind::terminate()) {
-        Ok(signal) => signal,
-        Err(error) => {
-            tracing::error!("Failed to install SIGTERM handler: {error}");
-            return;
-        }
-    };
+#[cfg(unix)]
+impl ShutdownSignals {
+    fn new() -> Result<Self> {
+        use tokio::signal::unix::{signal, SignalKind};
 
-    tokio::select! {
-        result = tokio::signal::ctrl_c() => {
-            match result {
-                Ok(()) => tracing::info!("Received SIGINT, starting graceful shutdown"),
-                Err(error) => tracing::error!("Failed to listen for SIGINT: {error}"),
+        Ok(Self {
+            sigint: signal(SignalKind::interrupt()).context("Failed to install SIGINT handler")?,
+            sigterm: signal(SignalKind::terminate())
+                .context("Failed to install SIGTERM handler")?,
+        })
+    }
+
+    async fn wait(&mut self) -> Result<()> {
+        tokio::select! {
+            result = self.sigint.recv() => {
+                result.context("SIGINT signal stream closed unexpectedly")?;
+                tracing::info!("Received SIGINT, starting graceful shutdown");
+            }
+            result = self.sigterm.recv() => {
+                result.context("SIGTERM signal stream closed unexpectedly")?;
+                tracing::info!("Received SIGTERM, starting graceful shutdown");
             }
         }
-        result = sigterm.recv() => {
-            match result {
-                Some(()) => tracing::info!("Received SIGTERM, starting graceful shutdown"),
-                None => tracing::error!("SIGTERM signal stream closed unexpectedly"),
-            }
-        }
+        Ok(())
     }
 }
 
 #[cfg(not(unix))]
-async fn shutdown_signal() {
-    match tokio::signal::ctrl_c().await {
-        Ok(()) => tracing::info!("Received Ctrl-C, starting graceful shutdown"),
-        Err(error) => tracing::error!("Failed to listen for Ctrl-C: {error}"),
+struct ShutdownSignals {
+    ctrl_c: tokio::signal::windows::CtrlC,
+}
+
+#[cfg(not(unix))]
+impl ShutdownSignals {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            ctrl_c: tokio::signal::windows::ctrl_c().context("Failed to install Ctrl-C handler")?,
+        })
+    }
+
+    async fn wait(&mut self) -> Result<()> {
+        self.ctrl_c
+            .recv()
+            .await
+            .context("Ctrl-C signal stream closed unexpectedly")?;
+        tracing::info!("Received Ctrl-C, starting graceful shutdown");
+        Ok(())
     }
 }
 
@@ -137,6 +158,8 @@ async fn run() -> Result<()> {
     match &cli.command {
         Some(command) => match command {
             Commands::Run(cfg) => {
+                let mut shutdown_signals = ShutdownSignals::new()?;
+
                 // Configure logging - use stderr for stdio transport to avoid interfering with MCP protocol
                 let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| {
@@ -204,18 +227,21 @@ async fn run() -> Result<()> {
                 let transport = stdio_transport();
                 let running_service = tokio::select! {
                     result = serve_server(server, transport) => result?,
-                    () = shutdown_signal() => {
+                    result = shutdown_signals.wait() => {
+                        result?;
                         tracing::info!("MCP server shutting down");
                         return Ok(());
                     }
                 };
 
-                shutdown_signal().await;
+                shutdown_signals.wait().await?;
                 let _ = running_service.cancel().await;
 
                 tracing::info!("MCP server shutting down");
             }
             Commands::Serve(cfg) => {
+                let mut shutdown_signals = ShutdownSignals::new()?;
+
                 // Configure logging for HTTP-based transports
                 let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| {
@@ -342,9 +368,11 @@ async fn run() -> Result<()> {
                         // Override only what the operator chose, so the `Host`
                         // allow list resolved above stays in place. A literal
                         // struct here would silently drop it.
+                        let cancellation_token = CancellationToken::new();
                         let http_config = http_config
                             .with_legacy_session_mode(legacy_sessions)
-                            .with_json_response(json_response);
+                            .with_json_response(json_response)
+                            .with_cancellation_token(cancellation_token.clone());
 
                         let service = StreamableHttpService::new(
                             move || Ok(server.clone()),
@@ -360,9 +388,15 @@ async fn run() -> Result<()> {
                         let tcp_listener = tokio::net::TcpListener::bind(&bind_address).await?;
 
                         // Spawn the server in a background task
+                        let (shutdown_result_tx, shutdown_result_rx) =
+                            tokio::sync::oneshot::channel();
                         let server_handle = tokio::spawn(async move {
                             axum::serve(tcp_listener, router)
-                                .with_graceful_shutdown(shutdown_signal())
+                                .with_graceful_shutdown(async move {
+                                    let result = shutdown_signals.wait().await;
+                                    cancellation_token.cancel();
+                                    let _ = shutdown_result_tx.send(result);
+                                })
                                 .await
                         });
 
@@ -379,6 +413,9 @@ async fn run() -> Result<()> {
 
                         // Wait for the server task to complete
                         server_handle.await??;
+                        shutdown_result_rx
+                            .await
+                            .context("MCP server stopped before receiving a shutdown signal")??;
                     }
                 }
 

--- a/crates/wassette-mcp-server/src/main.rs
+++ b/crates/wassette-mcp-server/src/main.rs
@@ -47,6 +47,10 @@ use server::McpServer;
 use tools::ToolName;
 use utils::{format_build_info, load_component_registry, parse_env_var};
 
+// Allow active HTTP connections five seconds to finish, leaving half of
+// Docker's default ten-second stop grace period for final process teardown.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
 #[cfg(unix)]
 struct ShutdownSignals {
     sigint: tokio::signal::unix::Signal,
@@ -192,14 +196,20 @@ async fn run() -> Result<()> {
                     json_response: _,
                 } = config;
 
-                let lifecycle_manager = LifecycleManager::builder(component_dir)
-                    .with_environment_vars(environment_vars)
-                    .with_secrets_dir(secrets_dir)
-                    .with_oci_client(oci_client::Client::default())
-                    .with_http_client(reqwest::Client::default())
-                    .with_eager_loading(false)
-                    .build()
-                    .await?;
+                let lifecycle_manager = tokio::select! {
+                    result = LifecycleManager::builder(component_dir)
+                        .with_environment_vars(environment_vars)
+                        .with_secrets_dir(secrets_dir)
+                        .with_oci_client(oci_client::Client::default())
+                        .with_http_client(reqwest::Client::default())
+                        .with_eager_loading(false)
+                        .build() => result?,
+                    result = shutdown_signals.wait() => {
+                        result?;
+                        tracing::info!("MCP server shutting down");
+                        return Ok(());
+                    }
+                };
 
                 let server = McpServer::new(
                     lifecycle_manager.clone(),
@@ -293,14 +303,20 @@ async fn run() -> Result<()> {
                 // Keep a clone of component_dir for provisioning
                 let component_dir_path = component_dir.clone();
 
-                let lifecycle_manager = LifecycleManager::builder(component_dir)
-                    .with_environment_vars(environment_vars)
-                    .with_secrets_dir(secrets_dir)
-                    .with_oci_client(oci_client::Client::default())
-                    .with_http_client(reqwest::Client::default())
-                    .with_eager_loading(false)
-                    .build()
-                    .await?;
+                let lifecycle_manager = tokio::select! {
+                    result = LifecycleManager::builder(component_dir)
+                        .with_environment_vars(environment_vars)
+                        .with_secrets_dir(secrets_dir)
+                        .with_oci_client(oci_client::Client::default())
+                        .with_http_client(reqwest::Client::default())
+                        .with_eager_loading(false)
+                        .build() => result?,
+                    result = shutdown_signals.wait() => {
+                        result?;
+                        tracing::info!("MCP server shutting down");
+                        return Ok(());
+                    }
+                };
 
                 // Provision components from manifest if provided
                 if let Some(manifest) = &manifest {
@@ -313,10 +329,16 @@ async fn run() -> Result<()> {
                         &component_dir_path,
                     );
 
-                    provisioner
-                        .provision()
-                        .await
-                        .context("Component provisioning failed")?;
+                    tokio::select! {
+                        result = provisioner.provision() => {
+                            result.context("Component provisioning failed")?;
+                        }
+                        result = shutdown_signals.wait() => {
+                            result?;
+                            tracing::info!("MCP server shutting down");
+                            return Ok(());
+                        }
+                    }
 
                     tracing::info!("All components provisioned successfully");
                 }
@@ -390,7 +412,7 @@ async fn run() -> Result<()> {
                         // Spawn the server in a background task
                         let (shutdown_result_tx, shutdown_result_rx) =
                             tokio::sync::oneshot::channel();
-                        let server_handle = tokio::spawn(async move {
+                        let mut server_handle = tokio::spawn(async move {
                             axum::serve(tcp_listener, router)
                                 .with_graceful_shutdown(async move {
                                     let result = shutdown_signals.wait().await;
@@ -411,11 +433,20 @@ async fn run() -> Result<()> {
                         );
                         tracing::info!("Build info available at http://{}/info", bind_address);
 
-                        // Wait for the server task to complete
-                        server_handle.await??;
                         shutdown_result_rx
                             .await
                             .context("MCP server stopped before receiving a shutdown signal")??;
+
+                        // Wait for active connections to finish.
+                        match tokio::time::timeout(DRAIN_TIMEOUT, &mut server_handle).await {
+                            Ok(result) => result??,
+                            Err(_) => {
+                                tracing::warn!(
+                                    "HTTP connection drain deadline passed; dropping remaining connections"
+                                );
+                                server_handle.abort();
+                            }
+                        }
                     }
                 }
 

--- a/crates/wassette-mcp-server/src/main.rs
+++ b/crates/wassette-mcp-server/src/main.rs
@@ -10,6 +10,8 @@
 // for that chain; see rust-lang/rust#159228.
 #![recursion_limit = "256"]
 
+use std::time::Duration;
+
 use anyhow::{bail, Context, Result};
 use clap::{CommandFactory, Parser};
 use clap_complete::{generate, shells};
@@ -44,6 +46,42 @@ use server::McpServer;
 use tools::ToolName;
 use utils::{format_build_info, load_component_registry, parse_env_var};
 
+#[cfg(unix)]
+async fn shutdown_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut sigterm = match signal(SignalKind::terminate()) {
+        Ok(signal) => signal,
+        Err(error) => {
+            tracing::error!("Failed to install SIGTERM handler: {error}");
+            return;
+        }
+    };
+
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => {
+            match result {
+                Ok(()) => tracing::info!("Received SIGINT, starting graceful shutdown"),
+                Err(error) => tracing::error!("Failed to listen for SIGINT: {error}"),
+            }
+        }
+        result = sigterm.recv() => {
+            match result {
+                Some(()) => tracing::info!("Received SIGTERM, starting graceful shutdown"),
+                None => tracing::error!("SIGTERM signal stream closed unexpectedly"),
+            }
+        }
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    match tokio::signal::ctrl_c().await {
+        Ok(()) => tracing::info!("Received Ctrl-C, starting graceful shutdown"),
+        Err(error) => tracing::error!("Failed to listen for Ctrl-C: {error}"),
+    }
+}
+
 // Health and info endpoint handlers
 mod endpoints {
     use axum::http::StatusCode;
@@ -72,8 +110,22 @@ mod endpoints {
     }
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("Failed to create Tokio runtime")?;
+    let result = runtime.block_on(run());
+    // Tokio's blocking stdin reader can outlive a canceled stdio service, and it
+    // never returns once the service is gone, so this budget is always spent in
+    // full on the stdio path. Keep it just wide enough for the blocking work
+    // that can still finish, which measures at roughly 15ms, rather than
+    // charging every stdio shutdown for a whole second of waiting.
+    runtime.shutdown_timeout(Duration::from_millis(100));
+    result
+}
+
+async fn run() -> Result<()> {
     let cli = Cli::parse();
 
     // Handle version flag
@@ -150,9 +202,15 @@ async fn main() -> Result<()> {
 
                 tracing::info!("Starting MCP server with stdio transport. Components will load in the background.");
                 let transport = stdio_transport();
-                let running_service = serve_server(server, transport).await?;
+                let running_service = tokio::select! {
+                    result = serve_server(server, transport) => result?,
+                    () = shutdown_signal() => {
+                        tracing::info!("MCP server shutting down");
+                        return Ok(());
+                    }
+                };
 
-                tokio::signal::ctrl_c().await?;
+                shutdown_signal().await;
                 let _ = running_service.cancel().await;
 
                 tracing::info!("MCP server shutting down");
@@ -304,9 +362,7 @@ async fn main() -> Result<()> {
                         // Spawn the server in a background task
                         let server_handle = tokio::spawn(async move {
                             axum::serve(tcp_listener, router)
-                                .with_graceful_shutdown(async {
-                                    tokio::signal::ctrl_c().await.unwrap()
-                                })
+                                .with_graceful_shutdown(shutdown_signal())
                                 .await
                         });
 
@@ -322,7 +378,7 @@ async fn main() -> Result<()> {
                         tracing::info!("Build info available at http://{}/info", bind_address);
 
                         // Wait for the server task to complete
-                        let _ = server_handle.await;
+                        server_handle.await??;
                     }
                 }
 

--- a/crates/wassette-mcp-server/tests/common/mod.rs
+++ b/crates/wassette-mcp-server/tests/common/mod.rs
@@ -3,8 +3,17 @@
 
 use std::path::PathBuf;
 use std::sync::Once;
+#[cfg(unix)]
+use std::time::Duration;
 
+#[cfg(unix)]
+use anyhow::{bail, ensure};
 use anyhow::{Context, Result};
+#[cfg(unix)]
+use tokio::process::Child;
+
+#[cfg(unix)]
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
 static FETCH_COMPONENT_BUILD: Once = Once::new();
 static FILESYSTEM_COMPONENT_BUILD: Once = Once::new();
@@ -113,4 +122,57 @@ pub async fn build_filesystem_component() -> Result<PathBuf> {
     }
 
     Ok(component_path)
+}
+
+#[cfg(unix)]
+async fn force_shutdown(child: &mut Child) -> Result<()> {
+    child
+        .start_kill()
+        .context("failed to force-kill the server process")?;
+    child
+        .wait()
+        .await
+        .context("failed to wait for the force-killed server process")?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[allow(dead_code)]
+pub async fn shutdown_child(child: &mut Child) -> Result<()> {
+    let pid = child.id().context("server process has no process ID")?;
+    let signal_status = std::process::Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .status()
+        .context("failed to send SIGTERM to the server process")?;
+
+    if !signal_status.success() {
+        force_shutdown(child).await?;
+        bail!("failed to send SIGTERM to server process {pid}: {signal_status}");
+    }
+
+    let status = match tokio::time::timeout(SHUTDOWN_TIMEOUT, child.wait()).await {
+        Ok(result) => result.context("failed to wait for the server process")?,
+        Err(_) => {
+            force_shutdown(child).await?;
+            bail!(
+                "server process {pid} did not exit within {} seconds after SIGTERM",
+                SHUTDOWN_TIMEOUT.as_secs()
+            );
+        }
+    };
+
+    ensure!(
+        status.success(),
+        "server process {pid} exited unsuccessfully after SIGTERM: {status}"
+    );
+    Ok(())
+}
+
+#[cfg(not(unix))]
+#[allow(dead_code)]
+pub async fn shutdown_child(child: &mut tokio::process::Child) -> Result<()> {
+    child
+        .kill()
+        .await
+        .context("failed to stop the server process")
 }

--- a/crates/wassette-mcp-server/tests/stateless_http_integration_test.rs
+++ b/crates/wassette-mcp-server/tests/stateless_http_integration_test.rs
@@ -21,6 +21,9 @@ use serde_json::{json, Value};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::process::{Child, Command};
 
+mod common;
+use common::shutdown_child;
+
 /// The protocol revision that removed sessions and added the mirrored headers.
 const STATELESS_VERSION: &str = "2026-07-28";
 
@@ -44,11 +47,24 @@ async fn wait_until_listening(port: u16) -> Result<()> {
     bail!("wassette did not start listening on 127.0.0.1:{port}")
 }
 
-struct ServerGuard(Child);
+struct ServerGuard {
+    child: Child,
+    shutdown_complete: bool,
+}
+
+impl ServerGuard {
+    async fn shutdown(mut self) -> Result<()> {
+        shutdown_child(&mut self.child).await?;
+        self.shutdown_complete = true;
+        Ok(())
+    }
+}
 
 impl Drop for ServerGuard {
     fn drop(&mut self) {
-        let _ = self.0.start_kill();
+        if !self.shutdown_complete {
+            let _ = self.child.start_kill();
+        }
     }
 }
 
@@ -72,7 +88,10 @@ async fn spawn_server(port: u16, component_dir: &Path, extra_args: &[&str]) -> R
         .stderr(Stdio::null())
         .spawn()
         .context("failed to spawn `wassette serve --streamable-http`")?;
-    Ok(ServerGuard(child))
+    Ok(ServerGuard {
+        child,
+        shutdown_complete: false,
+    })
 }
 
 fn mcp_url(port: u16) -> String {
@@ -159,7 +178,7 @@ async fn read_json_rpc(response: reqwest::Response) -> Result<Value> {
 async fn stateless_tools_list_needs_no_initialize() -> Result<()> {
     let port = find_open_port().await?;
     let temp_dir = tempfile::tempdir()?;
-    let _server = spawn_server(port, temp_dir.path(), &[]).await?;
+    let server = spawn_server(port, temp_dir.path(), &[]).await?;
     wait_until_listening(port).await?;
 
     let client = reqwest::Client::new();
@@ -196,6 +215,7 @@ async fn stateless_tools_list_needs_no_initialize() -> Result<()> {
         "builtin tools should be listed, got: {tools:?}"
     );
 
+    server.shutdown().await?;
     Ok(())
 }
 
@@ -204,7 +224,7 @@ async fn stateless_tools_list_needs_no_initialize() -> Result<()> {
 async fn stateless_cacheable_lists_include_cache_hints() -> Result<()> {
     let port = find_open_port().await?;
     let temp_dir = tempfile::tempdir()?;
-    let _server = spawn_server(port, temp_dir.path(), &[]).await?;
+    let server = spawn_server(port, temp_dir.path(), &[]).await?;
     wait_until_listening(port).await?;
 
     let client = reqwest::Client::new();
@@ -246,6 +266,7 @@ async fn stateless_cacheable_lists_include_cache_hints() -> Result<()> {
         );
     }
 
+    server.shutdown().await?;
     Ok(())
 }
 
@@ -256,7 +277,7 @@ async fn stateless_cacheable_lists_include_cache_hints() -> Result<()> {
 async fn legacy_cacheable_lists_omit_cache_hints() -> Result<()> {
     let port = find_open_port().await?;
     let temp_dir = tempfile::tempdir()?;
-    let _server = spawn_server(port, temp_dir.path(), &[]).await?;
+    let server = spawn_server(port, temp_dir.path(), &[]).await?;
     wait_until_listening(port).await?;
 
     let client = reqwest::Client::new();
@@ -340,6 +361,7 @@ async fn legacy_cacheable_lists_omit_cache_hints() -> Result<()> {
         );
     }
 
+    server.shutdown().await?;
     Ok(())
 }
 
@@ -351,7 +373,7 @@ async fn legacy_cacheable_lists_omit_cache_hints() -> Result<()> {
 async fn stateless_header_body_mismatch_is_rejected() -> Result<()> {
     let port = find_open_port().await?;
     let temp_dir = tempfile::tempdir()?;
-    let _server = spawn_server(port, temp_dir.path(), &[]).await?;
+    let server = spawn_server(port, temp_dir.path(), &[]).await?;
     wait_until_listening(port).await?;
 
     let client = reqwest::Client::new();
@@ -379,6 +401,7 @@ async fn stateless_header_body_mismatch_is_rejected() -> Result<()> {
         "a header mismatch must report HeaderMismatch (-32020), got: {message}"
     );
 
+    server.shutdown().await?;
     Ok(())
 }
 
@@ -387,7 +410,7 @@ async fn stateless_header_body_mismatch_is_rejected() -> Result<()> {
 async fn stateless_missing_method_header_is_rejected() -> Result<()> {
     let port = find_open_port().await?;
     let temp_dir = tempfile::tempdir()?;
-    let _server = spawn_server(port, temp_dir.path(), &[]).await?;
+    let server = spawn_server(port, temp_dir.path(), &[]).await?;
     wait_until_listening(port).await?;
 
     let client = reqwest::Client::new();
@@ -417,6 +440,7 @@ async fn stateless_missing_method_header_is_rejected() -> Result<()> {
         "a missing standard header must report HeaderMismatch (-32020), got: {message}"
     );
 
+    server.shutdown().await?;
     Ok(())
 }
 
@@ -425,7 +449,7 @@ async fn stateless_missing_method_header_is_rejected() -> Result<()> {
 async fn stateless_tools_call_round_trips() -> Result<()> {
     let port = find_open_port().await?;
     let temp_dir = tempfile::tempdir()?;
-    let _server = spawn_server(port, temp_dir.path(), &[]).await?;
+    let server = spawn_server(port, temp_dir.path(), &[]).await?;
     wait_until_listening(port).await?;
 
     let client = reqwest::Client::new();
@@ -453,6 +477,7 @@ async fn stateless_tools_call_round_trips() -> Result<()> {
         "stateless tools/call returned an error: {message}"
     );
 
+    server.shutdown().await?;
     Ok(())
 }
 
@@ -464,7 +489,7 @@ async fn stateless_tools_call_round_trips() -> Result<()> {
 async fn legacy_initialize_still_issues_a_session() -> Result<()> {
     let port = find_open_port().await?;
     let temp_dir = tempfile::tempdir()?;
-    let _server = spawn_server(port, temp_dir.path(), &[]).await?;
+    let server = spawn_server(port, temp_dir.path(), &[]).await?;
     wait_until_listening(port).await?;
 
     let client = reqwest::Client::new();
@@ -491,6 +516,7 @@ async fn legacy_initialize_still_issues_a_session() -> Result<()> {
         "a legacy initialize must still mint a session id"
     );
 
+    server.shutdown().await?;
     Ok(())
 }
 
@@ -574,7 +600,7 @@ async fn wait_for_sse_message(
 async fn stateless_subscription_receives_tool_list_changed() -> Result<()> {
     let port = find_open_port().await?;
     let temp_dir = tempfile::tempdir()?;
-    let _server = spawn_server(port, temp_dir.path(), &[]).await?;
+    let server = spawn_server(port, temp_dir.path(), &[]).await?;
     wait_until_listening(port).await?;
 
     let client = reqwest::Client::new();
@@ -614,6 +640,7 @@ async fn stateless_subscription_receives_tool_list_changed() -> Result<()> {
         "the subscription stream must carry the tool list change: {notification}"
     );
 
+    server.shutdown().await?;
     Ok(())
 }
 
@@ -624,7 +651,7 @@ async fn stateless_subscription_receives_tool_list_changed() -> Result<()> {
 async fn stateless_subscription_receives_tool_list_changed_after_unload() -> Result<()> {
     let port = find_open_port().await?;
     let temp_dir = tempfile::tempdir()?;
-    let _server = spawn_server(port, temp_dir.path(), &[]).await?;
+    let server = spawn_server(port, temp_dir.path(), &[]).await?;
     wait_until_listening(port).await?;
 
     let client = reqwest::Client::new();
@@ -685,6 +712,7 @@ async fn stateless_subscription_receives_tool_list_changed_after_unload() -> Res
         "unloading must invalidate subscribed tool lists: {notification}"
     );
 
+    server.shutdown().await?;
     Ok(())
 }
 
@@ -695,7 +723,7 @@ async fn stateless_subscription_receives_tool_list_changed_after_unload() -> Res
 async fn stateless_subscription_is_silent_for_non_mutating_tool() -> Result<()> {
     let port = find_open_port().await?;
     let temp_dir = tempfile::tempdir()?;
-    let _server = spawn_server(port, temp_dir.path(), &[]).await?;
+    let server = spawn_server(port, temp_dir.path(), &[]).await?;
     wait_until_listening(port).await?;
 
     let client = reqwest::Client::new();
@@ -732,6 +760,7 @@ async fn stateless_subscription_is_silent_for_non_mutating_tool() -> Result<()> 
         "a non-mutating tool must not broadcast tools/list_changed: {notification:?}"
     );
 
+    server.shutdown().await?;
     Ok(())
 }
 
@@ -745,7 +774,7 @@ async fn stateless_subscription_is_silent_for_non_mutating_tool() -> Result<()> 
 async fn stateless_subscription_is_silent_when_load_fails() -> Result<()> {
     let port = find_open_port().await?;
     let temp_dir = tempfile::tempdir()?;
-    let _server = spawn_server(port, temp_dir.path(), &[]).await?;
+    let server = spawn_server(port, temp_dir.path(), &[]).await?;
     wait_until_listening(port).await?;
 
     let client = reqwest::Client::new();
@@ -784,6 +813,7 @@ async fn stateless_subscription_is_silent_when_load_fails() -> Result<()> {
         "a failed load-component must not broadcast tools/list_changed: {notification:?}"
     );
 
+    server.shutdown().await?;
     Ok(())
 }
 
@@ -792,7 +822,7 @@ async fn stateless_subscription_is_silent_when_load_fails() -> Result<()> {
 async fn json_response_returns_plain_json() -> Result<()> {
     let port = find_open_port().await?;
     let temp_dir = tempfile::tempdir()?;
-    let _server = spawn_server(port, temp_dir.path(), &["--json-response"]).await?;
+    let server = spawn_server(port, temp_dir.path(), &["--json-response"]).await?;
     wait_until_listening(port).await?;
 
     let client = reqwest::Client::new();
@@ -827,6 +857,7 @@ async fn json_response_returns_plain_json() -> Result<()> {
         "the JSON body should still carry the tool list: {message}"
     );
 
+    server.shutdown().await?;
     Ok(())
 }
 
@@ -838,7 +869,7 @@ async fn json_response_returns_plain_json() -> Result<()> {
 async fn legacy_sessions_disabled_removes_the_session_lifecycle() -> Result<()> {
     let port = find_open_port().await?;
     let temp_dir = tempfile::tempdir()?;
-    let _server = spawn_server(port, temp_dir.path(), &["--legacy-sessions=false"]).await?;
+    let server = spawn_server(port, temp_dir.path(), &["--legacy-sessions=false"]).await?;
     wait_until_listening(port).await?;
 
     let client = reqwest::Client::new();
@@ -885,5 +916,6 @@ async fn legacy_sessions_disabled_removes_the_session_lifecycle() -> Result<()> 
         "DELETE /mcp must not terminate a session once legacy sessions are off"
     );
 
+    server.shutdown().await?;
     Ok(())
 }

--- a/crates/wassette-mcp-server/tests/stateless_http_integration_test.rs
+++ b/crates/wassette-mcp-server/tests/stateless_http_integration_test.rs
@@ -556,6 +556,23 @@ async fn open_subscription(client: &reqwest::Client, port: u16) -> Result<reqwes
     Ok(response)
 }
 
+/// SIGTERM completes successfully while a stateless subscription remains open.
+#[cfg(unix)]
+#[tokio::test]
+async fn sigterm_closes_open_stateless_subscription() -> Result<()> {
+    let port = find_open_port().await?;
+    let temp_dir = tempfile::tempdir()?;
+    let server = spawn_server(port, temp_dir.path(), &[]).await?;
+    wait_until_listening(port).await?;
+
+    let client = reqwest::Client::new();
+    let subscription = open_subscription(&client, port).await?;
+
+    server.shutdown().await?;
+    drop(subscription);
+    Ok(())
+}
+
 /// Read SSE `data:` payloads until one satisfies `predicate`, or time out.
 async fn wait_for_sse_message(
     response: reqwest::Response,

--- a/crates/wassette-mcp-server/tests/transport_integration_test.rs
+++ b/crates/wassette-mcp-server/tests/transport_integration_test.rs
@@ -25,7 +25,7 @@ use tokio::time::sleep;
 use wassette::LifecycleManager;
 
 mod common;
-use common::build_fetch_component;
+use common::{build_fetch_component, shutdown_child};
 
 const DOCKER_REGISTRY_PORT: u16 = 5000;
 
@@ -627,8 +627,7 @@ async fn test_stdio_transport() -> Result<()> {
     assert!(tool_names.contains(&"load-component".to_string()));
     assert!(tool_names.contains(&"unload-component".to_string()));
 
-    // Clean up
-    child.kill().await.ok();
+    shutdown_child(&mut child).await?;
 
     Ok(())
 }
@@ -860,8 +859,7 @@ async fn test_tool_list_notification() -> Result<()> {
     );
     println!("✓ New tools from loaded component are present in the list");
 
-    // Clean up
-    child.kill().await.ok();
+    shutdown_child(&mut child).await?;
 
     Ok(())
 }
@@ -911,8 +909,7 @@ async fn test_http_transport() -> Result<()> {
 
     assert_eq!(response.status(), reqwest::StatusCode::OK);
 
-    // Clean up
-    child.kill().await.ok();
+    shutdown_child(&mut child).await?;
 
     Ok(())
 }
@@ -978,8 +975,7 @@ async fn test_default_stdio_transport() -> Result<()> {
     assert_eq!(response["id"], 1);
     assert!(response["result"].is_object());
 
-    // Clean up
-    child.kill().await.ok();
+    shutdown_child(&mut child).await?;
 
     Ok(())
 }
@@ -1171,8 +1167,7 @@ async fn test_disable_builtin_tools() -> Result<()> {
         "Tool call should have failed"
     );
 
-    // Clean up
-    child.kill().await.ok();
+    shutdown_child(&mut child).await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

`wassette serve` installs no SIGTERM handler. The only signal it waited on was
`tokio::signal::ctrl_c()`, which is SIGINT, on both the stdio path and the future
handed to axum's `with_graceful_shutdown`.

`docker stop` and Kubernetes both send SIGTERM and escalate to SIGKILL after a grace
period, so Wassette was always hard-killed: axum's graceful shutdown never ran,
in-flight MCP requests were cut rather than drained, and open `subscriptions/listen`
streams were severed without the close the graceful path would give them.

The same gap made coverage misleading. The integration harness dropped its server
guard into `start_kill()`, i.e. SIGKILL, and a SIGKILLed process never flushes LLVM
profile data, so `cargo llvm-cov` attributed 0.00% to `server.rs` even though the
end-to-end tests exercise it.

## Changes

Both halves are needed. Changing the harness alone would not help, because nothing
handled SIGTERM and the process would still die abruptly.

- A shared `shutdown_signal()` helper that resolves on either SIGINT or SIGTERM,
  used by the stdio path in place of the bare `ctrl_c()` before
  `running_service.cancel()`, and by the streamable HTTP path as the future given to
  `with_graceful_shutdown`. It logs which signal arrived, so an operator can tell the
  two apart. The previous `.unwrap()` inside the HTTP shutdown future is gone.
  `tokio::signal::unix` is Unix-only, so the helper is `#[cfg(unix)]` with a
  ctrl-C-only fallback elsewhere.
- `#[tokio::main]` is replaced by an explicit runtime so that shutdown can be bounded.
  Tokio's blocking stdin reader can outlive a cancelled stdio service and never
  returns once that service is gone, so dropping the runtime would otherwise wait on
  it forever. The budget is 100ms, which is roughly 6x the blocking work that can
  still finish.
- The test harness gets `common::shutdown_child()`, which sends SIGTERM and awaits
  `Child::wait()` with a bounded timeout. `Drop` cannot await, so the forced
  `start_kill()` remains only as a fallback for tests that fail early or exceed the
  timeout. Applied to the stateless HTTP guard and to the forced-cleanup sites in
  `transport_integration_test.rs`.

## Verification

SIGTERM against the built binary, before and after:

| | HTTP | stdio |
|---|---|---|
| `main` | 143 (killed) | 143 (killed) |
| this branch | 0, ~11ms | 0, ~115ms |

`server.rs` coverage from `stateless_http_integration_test` alone goes from 0.00% to
81.42% of lines (306 regions, 76.47%), confirming the profile data now flushes.

`just ci-build-test`, `cargo +nightly fmt --all -- --check` and
`cargo clippy --workspace` all pass, as does `clippy --all-targets`, which covers the
test code this touches.

Fixes the deployment gap described alongside #757 and #759.