### PR TITLE
chore(examples): stop publishing the context7-rs example component

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -91,8 +91,6 @@ jobs:
             file: fetch-rs.wasm
           - name: brave-search-rs
             file: brave-search-rs.wasm
-          - name: context7-rs
-            file: context7-rs.wasm
           - name: get-open-meteo-weather-js
             file: get-open-meteo-weather-js.wasm
     steps:

--- a/component-registry.json
+++ b/component-registry.json
@@ -50,11 +50,6 @@
         "uri": "oci://ghcr.io/microsoft/brave-search-rs:latest"
     },
     {
-        "name": "Context7",
-        "description": "A library documentation search component using Context7 API written in Rust",
-        "uri": "oci://ghcr.io/microsoft/context7-rs:latest"
-    },
-    {
         "name": "Go Module Information",
         "description": "A Go module component",
         "uri": "oci://ghcr.io/microsoft/gomodule-go:latest"

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -1310,8 +1310,8 @@ mod tests {
             .as_array()
             .ok_or_else(|| anyhow::anyhow!("Components is not an array"))?;
 
-        // Should return all 12 components from component-registry.json
-        assert_eq!(components.len(), 12);
+        // Should return all 11 components from component-registry.json
+        assert_eq!(components.len(), 11);
 
         Ok(())
     }
@@ -1445,8 +1445,8 @@ mod tests {
 
         // Should match components with either "weather" or "rust"
         // Weather Server, Open-Meteo Weather, arXiv Research (Rust), Fetch (Rust),
-        // Filesystem (Rust), Brave Search (Rust), Context7 (Rust)
-        assert_eq!(components.len(), 7);
+        // Filesystem (Rust), Brave Search (Rust)
+        assert_eq!(components.len(), 6);
 
         Ok(())
     }
@@ -1508,7 +1508,7 @@ mod tests {
         let content1_json = serde_json::to_value(&result1.content)?;
         let text1 = content1_json[0]["text"].as_str().unwrap();
         let response1: Value = serde_json::from_str(text1)?;
-        assert_eq!(response1["components"].as_array().unwrap().len(), 12);
+        assert_eq!(response1["components"].as_array().unwrap().len(), 11);
 
         // Test 2: Query with single term
         let mut args2 = serde_json::Map::new();

--- a/crates/wassette-mcp-server/tests/registry_integration_test.rs
+++ b/crates/wassette-mcp-server/tests/registry_integration_test.rs
@@ -110,10 +110,10 @@ async fn test_registry_search_all() -> Result<()> {
 
     let json = ctx.parse_json_output(&stdout)?;
     assert_eq!(json["status"], "success");
-    assert_eq!(json["count"], 12); // Total components in registry
+    assert_eq!(json["count"], 11); // Total components in registry
 
     let components = json["components"].as_array().unwrap();
-    assert_eq!(components.len(), 12);
+    assert_eq!(components.len(), 11);
 
     // Verify each component has required fields
     for component in components {
@@ -192,8 +192,8 @@ async fn test_registry_search_matches_description() -> Result<()> {
 
     let json = ctx.parse_json_output(&stdout)?;
     assert_eq!(json["status"], "success");
-    // Should match "arXiv Research", "Fetch", "Filesystem", "Brave Search", and "Context7" which have "Rust" in description
-    assert_eq!(json["count"], 5);
+    // Should match "arXiv Research", "Fetch", "Filesystem", and "Brave Search" which have "Rust" in description
+    assert_eq!(json["count"], 4);
 
     Ok(())
 }


### PR DESCRIPTION
The published component for `examples/context7-rs/` was deleted prior to a rename but the hardcoded publish matrix in `.github/workflows/examples.yml` would recreate it on the next push touching `examples/`. Remove the `context7-rs` entry from that matrix so it is no longer pushed. The example source under  is kept, and the Justfile recipes still build it.