### PR TITLE
fix(ci): prune channel builds by publish time, not commit date

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -159,8 +159,8 @@ jobs:
             gh release list \
               --repo "$GITHUB_REPOSITORY" \
               --limit 100 \
-              --json tagName,createdAt,isPrerelease \
-              --jq '[.[] | select(.isPrerelease and (.tagName | startswith("latest-")))] | sort_by(.createdAt) | reverse | .[5:] | .[].tagName'
+              --json tagName,publishedAt,isPrerelease \
+              --jq '[.[] | select(.isPrerelease and (.tagName | startswith("latest-")))] | sort_by(.publishedAt) | reverse | .[5:] | .[].tagName'
           )
 
           for OLD_TAG in "${OLD_TAGS[@]}"; do


### PR DESCRIPTION
## The bug

The `latest` channel's prune step sorts on `createdAt`:

```jq
[.[] | select(.isPrerelease and (.tagName | startswith("latest-")))]
| sort_by(.createdAt) | reverse | .[5:] | .[].tagName
```

A release's `created_at` is **the committer date of the tagged commit**, not the time the release
was made. That is `published_at`. The first two channel builds show it to the second:

| release | `created_at` | commit committer date | `published_at` |
| --- | --- | --- | --- |
| `latest-20260825-2048-0a0c381` | 20:40:15 | 20:40:15 | 21:09:15 |
| `latest-20260825-2111-faddeb8` | 21:00:07 | 21:00:07 | 21:24:44 |

## Why it matters

It is invisible while every channel build is cut from a recent commit, which is why it survived
the first two dispatches. It bites precisely when the `ref` input is used for the thing it exists
for: building an older commit to reproduce a bug.

With five channel builds already present, dispatch a build of a commit from last week. It
publishes, then the prune ranks it as the oldest of six by commit date and **deletes the release
that same run has just published**, tag included.

Run against a fixture of six channel builds where the newest by publish time builds an 18 August
commit:

```
sort_by(.createdAt)    -> deletes latest-20260826-1800-0ldc0mm   # the one just published
sort_by(.publishedAt)  -> deletes latest-20260825-2048-0a0c381   # the genuinely oldest
```

## The fix

Sort on `publishedAt`, which `gh release list --json` exposes. The prefix and prerelease filters
are unchanged, so releases and versioned prereleases are still never considered; the fixture
confirms `v0.6.0` and `v0.6.0-test2` are untouched either way.

Sorting on `tagName` would also work, since the tag embeds a fixed-width timestamp, and is what
`scripts/install.sh` already does to resolve the channel. I went with `publishedAt` as the more
direct statement of intent, but I would switch to `tagName` if you would rather the two places
agree on one mechanism.

## Verification

`actionlint` clean, YAML parses, and both jq expressions were run against the fixture above rather
than reasoned about. Not verified end to end: reproducing this for real needs six dispatches, so
the evidence is the field semantics confirmed against live data plus the fixture, not a live prune.
