### PR TITLE
fix: serve --manifest never attaches the policy it synthesizes

### DIFF
--- a/crates/wassette-mcp-server/src/provisioning_controller.rs
+++ b/crates/wassette-mcp-server/src/provisioning_controller.rs
@@ -2,12 +2,12 @@
 // Licensed under the MIT license.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{bail, Context, Result};
 use wassette::{LifecycleManager, SecretsManager};
 
-use crate::manifest::{ComponentDeclaration, ProvisioningManifest};
+use crate::manifest::{ComponentDeclaration, InlinePermissions, ProvisioningManifest};
 use crate::permission_synthesis;
 
 /// Controller for provisioning components from a manifest
@@ -84,26 +84,32 @@ impl<'a> ProvisioningController<'a> {
         self.seed_secrets(component)
             .context("Failed to seed secrets")?;
 
-        // Step 2: Synthesize and write policy file
-        let policy_path = self
-            .synthesize_policy(component)
-            .context("Failed to synthesize policy")?;
-
-        tracing::debug!(
-            "Synthesized policy for component to: {}",
-            policy_path.display()
-        );
-
-        // Step 3: Load component using existing lifecycle manager
-        // Note: The lifecycle manager will automatically:
-        // - Download the component from the URI
-        // - Compile and cache it
-        // - Load the co-located policy file we just created
-        // - Register the component and its tools
-        self.lifecycle_manager
+        // Step 2: Load the component to obtain its authoritative component ID
+        let load_outcome = self
+            .lifecycle_manager
             .load_component(&component.uri)
             .await
             .with_context(|| format!("Failed to load component from URI: {}", component.uri))?;
+
+        // Step 3: Synthesize and attach a policy when permissions were declared
+        if has_synthesizable_permissions(component) {
+            self.synthesize_policy(component, &load_outcome.component_id)
+                .await
+                .context("Failed to synthesize and attach policy")?;
+
+            if self
+                .lifecycle_manager
+                .get_policy_info(&load_outcome.component_id)
+                .await
+                .is_none()
+            {
+                tracing::warn!(
+                    component_id = %load_outcome.component_id,
+                    component_uri = %component.uri,
+                    "Component manifest declared permissions but no policy is attached after provisioning"
+                );
+            }
+        }
 
         // Step 4: Verify digest if specified
         if let Some(digest) = &component.digest {
@@ -159,29 +165,57 @@ impl<'a> ProvisioningController<'a> {
         Ok(())
     }
 
-    /// Synthesize policy from inline permissions
-    fn synthesize_policy(&self, component: &ComponentDeclaration) -> Result<PathBuf> {
-        // Synthesize policy YAML
+    /// Synthesize and attach a policy from inline permissions
+    async fn synthesize_policy(
+        &self,
+        component: &ComponentDeclaration,
+        component_id: &str,
+    ) -> Result<()> {
         let policy_yaml = permission_synthesis::synthesize_policy_yaml(
             &component.permissions,
             component.name.as_deref(),
         )
         .context("Failed to synthesize policy from inline permissions")?;
 
-        // We need to generate a predictable filename for the policy
-        // The lifecycle manager expects {component_id}.policy.yaml
-        // For now, we'll use a hash of the URI as a temporary name
-        // The lifecycle manager will rename it after loading
+        let policy_source_path = self
+            .plugin_dir
+            .join(format!("{component_id}.manifest-policy.yaml"));
+        tokio::fs::write(&policy_source_path, policy_yaml)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to write synthesized policy to: {}",
+                    policy_source_path.display()
+                )
+            })?;
 
-        // Create a temporary policy file that will be discovered by the loader
-        let temp_policy_name = format!("temp_{}.policy.yaml", hash_string(&component.uri));
-        let policy_path = self.plugin_dir.join(temp_policy_name);
+        let policy_uri = format!("file://{}", policy_source_path.display());
+        let attach_result = self
+            .lifecycle_manager
+            .attach_policy(component_id, &policy_uri)
+            .await;
+        let cleanup_result = tokio::fs::remove_file(&policy_source_path).await;
 
-        std::fs::write(&policy_path, policy_yaml).with_context(|| {
-            format!("Failed to write policy file to: {}", policy_path.display())
-        })?;
-
-        Ok(policy_path)
+        match (attach_result, cleanup_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(attach_error), Ok(())) => Err(attach_error).with_context(|| {
+                format!("Failed to attach synthesized policy to component {component_id}")
+            }),
+            (Ok(()), Err(cleanup_error)) => {
+                tracing::warn!(
+                    path = %policy_source_path.display(),
+                    error = %cleanup_error,
+                    "Failed to remove synthesized policy source after attaching policy"
+                );
+                Ok(())
+            }
+            (Err(attach_error), Err(cleanup_error)) => Err(attach_error).with_context(|| {
+                format!(
+                    "Failed to attach synthesized policy to component {component_id}; also failed to remove {}: {cleanup_error}",
+                    policy_source_path.display()
+                )
+            }),
+        }
     }
 
     /// Verify component digest (SHA-256)
@@ -205,35 +239,26 @@ impl<'a> ProvisioningController<'a> {
     }
 }
 
-/// Hash a string to create a temporary filename
-fn hash_string(s: &str) -> String {
-    // Simple hash for temporary filenames
-    // In production, we'd use a proper hash function
-    let hash = s
-        .bytes()
-        .fold(0u64, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u64));
-    format!("{:016x}", hash)
+/// Report whether the declaration carries permissions that synthesis can express.
+///
+/// `resources` is deliberately excluded. It is deferred to post-MVP and
+/// `permission_synthesis` never converts it, so a resources-only declaration would
+/// synthesize an empty policy and overwrite whatever policy the component already had.
+fn has_synthesizable_permissions(component: &ComponentDeclaration) -> bool {
+    let InlinePermissions {
+        network,
+        storage,
+        environment,
+        resources: _,
+    } = &component.permissions;
+
+    network.is_some() || storage.is_some() || environment.is_some()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::manifest::{
-        EnvironmentPermissions, EnvironmentRule, InlinePermissions, NetworkPermissions, NetworkRule,
-    };
-
-    #[test]
-    fn test_hash_string() {
-        let hash1 = hash_string("oci://example.com/component:latest");
-        let hash2 = hash_string("oci://example.com/component:v1.0.0");
-
-        // Hashes should be deterministic
-        assert_eq!(hash1, hash_string("oci://example.com/component:latest"));
-        assert_eq!(hash2, hash_string("oci://example.com/component:v1.0.0"));
-
-        // Different strings should have different hashes
-        assert_ne!(hash1, hash2);
-    }
+    use crate::manifest::{EnvironmentPermissions, EnvironmentRule, InlinePermissions};
 
     #[test]
     fn test_seed_secrets_basic() {
@@ -270,39 +295,5 @@ mod tests {
 
         // Cleanup
         std::env::remove_var("TEST_API_KEY");
-    }
-
-    #[test]
-    fn test_synthesize_policy() {
-        let _temp_dir = tempfile::tempdir().unwrap();
-
-        let component = ComponentDeclaration {
-            uri: "oci://example.com/test:latest".to_string(),
-            name: Some("test".to_string()),
-            digest: None,
-            permissions: InlinePermissions {
-                network: Some(NetworkPermissions {
-                    allow: vec![NetworkRule {
-                        host: "api.example.com".to_string(),
-                    }],
-                }),
-                storage: None,
-                environment: None,
-                resources: None,
-            },
-            retry_policy: None,
-        };
-
-        let _manifest = ProvisioningManifest {
-            version: 1,
-            components: vec![component.clone()],
-        };
-
-        // Create a mock provisioning controller
-        // (We can't fully initialize it without mocks, but we can test the helper)
-
-        // Verify hash is deterministic
-        let hash = hash_string(&component.uri);
-        assert_eq!(hash, hash_string(&component.uri));
     }
 }

--- a/crates/wassette-mcp-server/tests/cli_integration_test.rs
+++ b/crates/wassette-mcp-server/tests/cli_integration_test.rs
@@ -2,13 +2,14 @@
 // Licensed under the MIT license.
 use std::env;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use serde_json::Value;
 use tempfile::TempDir;
 use test_log::test;
+use tokio::net::{TcpListener, TcpStream};
 use tokio::process::Command as AsyncCommand;
 
 mod common;
@@ -126,6 +127,174 @@ impl CliTestContext {
     fn parse_json_output(&self, stdout: &str) -> Result<Value> {
         serde_json::from_str(stdout.trim()).context("Failed to parse JSON output")
     }
+}
+
+#[test(tokio::test)]
+async fn test_serve_manifest_attaches_declared_policy() -> Result<()> {
+    let ctx = CliTestContext::new().await?;
+    let component_path = build_fetch_component().await?;
+    let manifest_path = ctx.temp_dir.path().join("manifest.yaml");
+    tokio::fs::write(
+        &manifest_path,
+        format!(
+            "version: 1\ncomponents:\n  - uri: file://{}\n    permissions:\n      network:\n        allow:\n          - host: api.example.com\n",
+            component_path.display()
+        ),
+    )
+    .await?;
+
+    let mut command = AsyncCommand::new(&ctx.wassette_bin);
+    command
+        .args(["serve", "--manifest"])
+        .arg(&manifest_path)
+        .args([
+            "--disable-builtin-tools",
+            "--bind-address",
+            "127.0.0.1:0",
+            "--component-dir",
+        ])
+        .arg(&ctx.component_dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    let mut child = command.spawn().context("Failed to start wassette serve")?;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let policy_path = loop {
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!("wassette serve exited before provisioning completed: {status}");
+        }
+
+        let mut entries = tokio::fs::read_dir(&ctx.component_dir).await?;
+        let mut found = None;
+        while let Some(entry) = entries.next_entry().await? {
+            let file_name = entry.file_name();
+            let file_name = file_name.to_string_lossy();
+            if let Some(component_id) = file_name.strip_suffix(".wasm") {
+                let candidate = ctx
+                    .component_dir
+                    .join(format!("{component_id}.policy.yaml"));
+                let policy_source = ctx
+                    .component_dir
+                    .join(format!("{component_id}.manifest-policy.yaml"));
+                if tokio::fs::try_exists(&candidate).await?
+                    && !tokio::fs::try_exists(&policy_source).await?
+                {
+                    found = Some(candidate);
+                    break;
+                }
+            }
+        }
+
+        if let Some(path) = found {
+            break path;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "Timed out waiting for the manifest policy to be attached and its staging file to be removed"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    child.kill().await?;
+    child.wait().await?;
+
+    let policy_content = tokio::fs::read_to_string(&policy_path).await?;
+    assert!(policy_content.contains("api.example.com"));
+
+    let mut entries = tokio::fs::read_dir(&ctx.component_dir).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        assert!(!file_name.starts_with("temp_"));
+        assert!(!file_name.ends_with(".manifest-policy.yaml"));
+    }
+
+    Ok(())
+}
+
+#[test(tokio::test)]
+async fn test_serve_manifest_resources_only_preserves_existing_policy() -> Result<()> {
+    let ctx = CliTestContext::new().await?;
+    let component_path = build_fetch_component().await?;
+    let (stdout, stderr, exit_code) = ctx
+        .run_command(&[
+            "component",
+            "load",
+            &format!("file://{}", component_path.display()),
+        ])
+        .await?;
+    assert_eq!(exit_code, 0, "Load command failed with stderr: {stderr}");
+
+    let load_output: Value = ctx.parse_json_output(&stdout)?;
+    let component_id = load_output["id"].as_str().context("Missing component ID")?;
+    let granted_host = "preserved.example.com";
+    let (_, stderr, exit_code) = ctx
+        .run_command(&["permission", "grant", "network", component_id, granted_host])
+        .await?;
+    assert_eq!(
+        exit_code, 0,
+        "Grant network permission failed with stderr: {stderr}"
+    );
+
+    let policy_path = ctx
+        .component_dir
+        .join(format!("{component_id}.policy.yaml"));
+    let policy_content = tokio::fs::read_to_string(&policy_path).await?;
+    assert!(policy_content.contains(granted_host));
+
+    let manifest_path = ctx.temp_dir.path().join("manifest.yaml");
+    tokio::fs::write(
+        &manifest_path,
+        format!(
+            "version: 1\ncomponents:\n  - uri: file://{}\n    permissions:\n      resources:\n        memory_bytes: 67108864\n",
+            component_path.display()
+        ),
+    )
+    .await?;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let bind_address = listener.local_addr()?;
+    drop(listener);
+
+    let mut command = AsyncCommand::new(&ctx.wassette_bin);
+    command
+        .args(["serve", "--manifest"])
+        .arg(&manifest_path)
+        .arg("--bind-address")
+        .arg(bind_address.to_string())
+        .arg("--component-dir")
+        .arg(&ctx.component_dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    let mut child = command.spawn().context("Failed to start wassette serve")?;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!("wassette serve exited before becoming ready: {status}");
+        }
+        if TcpStream::connect(bind_address).await.is_ok() {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!("Timed out waiting for wassette serve to become ready");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    child.kill().await?;
+    child.wait().await?;
+
+    let policy_content = tokio::fs::read_to_string(&policy_path).await?;
+    assert!(
+        policy_content.contains(granted_host),
+        "Manifest provisioning replaced the existing policy: {policy_content}"
+    );
+
+    Ok(())
 }
 
 #[test(tokio::test)]

--- a/crates/wassette-mcp-server/tests/manifest_policy_call_integration_test.rs
+++ b/crates/wassette-mcp-server/tests/manifest_policy_call_integration_test.rs
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use std::convert::Infallible;
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
+use serde_json::{json, Value};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::process::{Child, Command};
+use tokio::task::JoinHandle;
+
+mod common;
+
+const STATELESS_VERSION: &str = "2026-07-28";
+const ORIGIN_BODY: &str = "manifest policy reached the loopback origin";
+
+async fn find_open_port() -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("failed to bind a random loopback port")?;
+    Ok(listener.local_addr()?.port())
+}
+
+async fn wait_until_listening(port: u16) -> Result<()> {
+    for _ in 0..100 {
+        if TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    bail!("wassette did not start listening on 127.0.0.1:{port}")
+}
+
+struct ServerGuard(Child);
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.0.start_kill();
+    }
+}
+
+async fn spawn_server(port: u16, component_dir: &Path, extra_args: &[&str]) -> Result<ServerGuard> {
+    let bind_address = format!("127.0.0.1:{port}");
+    let component_dir = format!("--component-dir={}", component_dir.display());
+    let mut args = vec![
+        "serve",
+        "--streamable-http",
+        "--bind-address",
+        &bind_address,
+        &component_dir,
+    ];
+    args.extend_from_slice(extra_args);
+
+    let child = Command::new(env!("CARGO_BIN_EXE_wassette"))
+        .args(&args)
+        .env("RUST_LOG", "error")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("failed to spawn `wassette serve --streamable-http`")?;
+    Ok(ServerGuard(child))
+}
+
+fn stateless_meta() -> Value {
+    json!({
+        "io.modelcontextprotocol/protocolVersion": STATELESS_VERSION,
+        "io.modelcontextprotocol/clientInfo": {
+            "name": "wassette-manifest-policy-test",
+            "version": "1.0.0",
+        },
+        "io.modelcontextprotocol/clientCapabilities": {},
+    })
+}
+
+async fn post_stateless(
+    client: &reqwest::Client,
+    port: u16,
+    method: &str,
+    name_header: Option<&str>,
+    params: Value,
+) -> Result<reqwest::Response> {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": params,
+    });
+
+    let mut request = client
+        .post(format!("http://127.0.0.1:{port}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("MCP-Protocol-Version", STATELESS_VERSION)
+        .header("Mcp-Method", method);
+    if let Some(name) = name_header {
+        request = request.header("Mcp-Name", name);
+    }
+
+    request
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("failed to POST stateless {method}"))
+}
+
+async fn read_json_rpc(response: reqwest::Response) -> Result<Value> {
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    let text = response.text().await.context("failed to read body")?;
+
+    if content_type.starts_with("text/event-stream") {
+        let payload = text
+            .lines()
+            .filter_map(|line| line.strip_prefix("data:").map(str::trim))
+            .find(|payload| !payload.is_empty())
+            .context("SSE response carried no data line")?;
+        return serde_json::from_str(payload).context("malformed SSE JSON-RPC payload");
+    }
+    serde_json::from_str(&text).context("malformed JSON-RPC payload")
+}
+
+struct OriginGuard {
+    port: u16,
+    task: JoinHandle<Result<()>>,
+}
+
+impl Drop for OriginGuard {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn spawn_origin() -> Result<OriginGuard> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("failed to bind the loopback origin")?;
+    let port = listener.local_addr()?.port();
+    let task = tokio::spawn(async move {
+        let (stream, _) = listener
+            .accept()
+            .await
+            .context("failed to accept an origin connection")?;
+        let service = service_fn(|_request: Request<hyper::body::Incoming>| async {
+            Ok::<_, Infallible>(
+                Response::builder()
+                    .header("Content-Type", "text/plain")
+                    .body(Full::new(Bytes::from_static(ORIGIN_BODY.as_bytes())))
+                    .expect("static origin response should be valid"),
+            )
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(stream), service)
+            .await
+            .context("failed to serve the origin response")
+    });
+
+    Ok(OriginGuard { port, task })
+}
+
+#[tokio::test]
+async fn manifest_network_permission_allows_tool_call() -> Result<()> {
+    let component_path = common::build_fetch_component().await?;
+    let origin = spawn_origin().await?;
+    let temp_dir = tempfile::tempdir()?;
+    let manifest_path = temp_dir.path().join("manifest.yaml");
+    tokio::fs::write(
+        &manifest_path,
+        format!(
+            "version: 1\ncomponents:\n  - uri: file://{}\n    permissions:\n      network:\n        allow:\n          - host: 127.0.0.1\n",
+            component_path.display()
+        ),
+    )
+    .await?;
+
+    let port = find_open_port().await?;
+    let manifest = manifest_path
+        .to_str()
+        .context("manifest path was not valid UTF-8")?;
+    let _server = spawn_server(port, temp_dir.path(), &["--manifest", manifest]).await?;
+    wait_until_listening(port).await?;
+
+    let client = reqwest::Client::new();
+    let response = post_stateless(
+        &client,
+        port,
+        "tools/call",
+        Some("fetch"),
+        json!({
+            "name": "fetch",
+            "arguments": {
+                "url": format!("http://127.0.0.1:{}/", origin.port),
+            },
+            "_meta": stateless_meta(),
+        }),
+    )
+    .await?;
+    assert_eq!(response.status(), 200, "tools/call should return HTTP 200");
+
+    let message = read_json_rpc(response).await?;
+    let rendered = message.to_string();
+    assert!(
+        !rendered.contains("HttpRequestDenied"),
+        "manifest-declared network permission was denied: {message}"
+    );
+    assert!(
+        rendered.contains(ORIGIN_BODY),
+        "fetch response did not contain the origin body: {message}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`wassette serve --manifest` parses a component's declared permissions correctly and
synthesizes correct policy YAML, then writes that file under a name the component loader
never looks for. The component loads with an empty allowlist and denies every request its
policy was supposed to permit.

The failure is silent. Provisioning logs `Successfully provisioned all components`, the
component appears in `tools/list`, and the tools only fail at call time with
`ErrorCode::HttpRequestDenied`:

```
WARN ... execute_component_call{component_id="microsoft_fetch-rs" function_name="fetch"}:
  wassette::http: HTTP request blocked by network policy
  uri=https://example.com/ allowed_hosts={}
```

`allowed_hosts={}` even though the manifest declared a host.

This combines badly with `--disable-builtin-tools`. That flag removes the `grant-*`
family, and `--manifest` is the only other way to grant a permission, so with both in use,
which is the natural configuration for an untrusted-agent deployment, there is no way to
grant a component any permission at all.

Enforcement is allow-list only, so it fails closed. This is a functionality bug, not a
security hole.

## Cause

`provisioning_controller.rs` synthesized the policy before loading the component, so it
did not yet know the component id, and worked around that with a temporary name:

```rust
// We need to generate a predictable filename for the policy
// The lifecycle manager expects {component_id}.policy.yaml
// For now, we'll use a hash of the URI as a temporary name
// The lifecycle manager will rename it after loading
let temp_policy_name = format!("temp_{}.policy.yaml", hash_string(&component.uri));
```

The comment states the requirement correctly and then does not meet it. No rename ever
happens. `component_storage.rs` builds the only path that is read as
`{component_id}.policy.yaml`, so the loader finds nothing and attaches no policy, and the
orphaned `temp_*.policy.yaml` accumulates in the component directory. The component id is
not the URI hash, so the two names can never coincide.

## Fix

Invert the ordering. Load the component first, take the authoritative id off the load
outcome, then stage the synthesized YAML as `{component_id}.manifest-policy.yaml` and
attach it through the existing `attach_policy` API, removing the staging file afterwards.

This avoids duplicating the private id resolution and avoids widening `load_component`
with a special policy path. `hash_string` and its tests are removed, since they only
covered the naming scheme that caused the bug.

Two smaller behaviors come with it:

- Removing the staging file is best effort. A cleanup failure warns and names the path
  rather than aborting server startup over a leftover file, since the policy is attached
  and the component is fully functional at that point.
- Synthesis is skipped entirely when a declaration carries nothing synthesis can express.
  Today that means a resources-only declaration: `resources` satisfies the "at least one
  permission type" rule in `InlinePermissions::validate`, but `permission_synthesis` never
  converts it, so synthesis would produce a document with every category `None`.
  `attach_policy` copies unconditionally over `{component_id}.policy.yaml`, so attaching
  that empty document would destroy a policy the component already had, for example one
  written earlier by `grant_permission`. Skipping preserves it.

After a successful synthesis, provisioning warns if no policy is attached, as a
post-condition check on the case where permissions were actually declared.

## Tests

Three additions, all local and hermetic. None of them reach the public internet.

- `test_serve_manifest_attaches_declared_policy` provisions from a manifest with a network
  permission and asserts the policy lands under the id-derived name with the declared host
  in it, and that no staging or `temp_*` file is left behind.
- `manifest_network_permission_allows_tool_call` is the end-to-end case: it binds a
  loopback origin server, declares that host in a manifest, starts
  `serve --streamable-http --manifest`, calls the `fetch` tool over MCP and asserts the
  origin body comes back and the response does not contain `HttpRequestDenied`. On the
  unfixed code this fails with exactly the denial from the bug report. A test that only
  asserts the component loads and appears in `tools/list` passes either way, which is what
  made this expensive to diagnose.
- `test_serve_manifest_resources_only_preserves_existing_policy` covers the skip above: it
  grants a network permission, provisions from a resources-only manifest, and asserts the
  grant survives.

## Validation

Found and reproduced on `8524e96`, linux_amd64, on Azure Linux 3 under Kata on AKS.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and
`cargo test -p wassette-mcp-server` are green on this branch.
