### PR TITLE
fix(ci): run the instrumented coverage suite once, not twice

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,10 @@ on:
       - 'MAINTAINERS'
       - 'NOTICE'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -129,8 +133,11 @@ jobs:
       run: cargo install cargo-llvm-cov
     - name: Generate coverage report
       run: |
-        cargo llvm-cov --all-features --workspace --ignore-run-fail --lcov --output-path lcov.info
-        cargo llvm-cov --all-features --workspace --ignore-run-fail --json --output-path coverage.json
+        # --no-report keeps the artifacts a plain run would have cleaned, so clean explicitly
+        cargo llvm-cov clean --workspace
+        cargo llvm-cov --all-features --workspace --ignore-run-fail --no-report
+        cargo llvm-cov report --lcov --output-path lcov.info
+        cargo llvm-cov report --json --output-path coverage.json
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.1.0
       with:


### PR DESCRIPTION
`test coverage` is the critical path for PR feedback, and it runs the instrumented test suite twice.

Over the last 19 completed `pull_request` runs of this workflow (2026-08-25 to 08-26):

| job | median |
| --- | --- |
| **test coverage** | **22.8m** |
| build | 14.7m |
| security audit | 5.2m |
| lint | 1.3m |
| everything else | under 0.6m |
| workflow wallclock | 22.8m |

Within `test coverage`, the `Generate coverage report` step medians **1293s**, so about 95 percent of the job. That step invoked `cargo llvm-cov` twice, once for `--lcov` and once for `--json`, and because a plain invocation cleans and rebuilds by default, each one re-ran the entire instrumented suite.

## What this changes

**Run once, report twice.** A single `--no-report` run, then two `cargo llvm-cov report` calls that each emit one format. This is the pattern cargo-llvm-cov documents for exactly this case. `report` accepts `--lcov`, `--json` and `--output-path`, and does not accept `--workspace` or `--ignore-run-fail`, so those stay on the run. Output filenames and contents are unchanged, so the Codecov upload, the coverage summary script that reads `coverage.data[0].totals.lines`, and the artifact upload all keep working as they are.

**Clean explicitly.** `--no-report` also disables the clean that a plain `cargo llvm-cov` performs by default, and this job restores a cache into `target/` immediately beforehand, so without it the change would not be behaviour-preserving and could move the reported percentage. `cargo llvm-cov clean --workspace` removes workspace member artifacts and profraw files, not third-party dependency artifacts, so the cache still does its job. The cargo-llvm-cov docs prescribe this for this flag combination.

**Concurrency group.** Pushing again to a PR currently leaves several full pipelines running and cancels none of them.

## Expected effect

The coverage job should land near 12 to 13m, at which point `build` at 14.7m becomes the critical path and workflow wallclock should be roughly **22.8m to 15m**.

The number I have not verified is whether one instrumented run really is about half of 1293s. If the two invocations were not costing the same, the win is smaller than this. CI on this PR is itself the first measurement, since `pull_request` runs the workflow from the PR head.

## Not included

Whether coverage should gate PRs at all is worth stating since it is the obvious alternative: it is not worth it. With this change the critical path becomes `build` at 14.7m, so dropping coverage from the gate entirely would save about 20 seconds more than this PR does, in exchange for losing per-PR coverage. If the pipeline needs to go below 15m, the target is `build`'s `Run tests` step at 720s.
