### PR TITLE
fix(ci): let the rust cache fall back to a partial restore

### DIFF
--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -3,18 +3,6 @@ name: Setup rust cache
 runs:
   using: composite
   steps:
-    - name: Get rust version
-      run: echo "RUST_VERSION=$(rustc --version | awk '{print $2}')" >> $GITHUB_ENV
-      shell: bash
-    - name: Get Cargo.lock SHA 
-      shell: bash
-      run: |
-        if command -v sha256sum >/dev/null 2>&1; then
-          echo "CARGO_LOCK_SHA=$(sha256sum Cargo.lock | awk '{print $1}')" >> $GITHUB_ENV
-        else
-          echo "CARGO_LOCK_SHA=$(shasum -a 256 Cargo.lock | awk '{print $1}')" >> $GITHUB_ENV
-        fi
     - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
       with:
-        shared-key: "wassette-${{ env.RUST_VERSION }}-${{ env.CARGO_LOCK_SHA }}"
-        
+        shared-key: "wassette"


### PR DESCRIPTION
`.github/actions/rust-cache` folds the `Cargo.lock` SHA into `shared-key`, which defeats the partial cache restore that `Swatinem/rust-cache` is built around.

## Why this matters

`Swatinem/rust-cache` constructs two keys (`src/config.ts`):

- `shared-key` is appended to the key prefix (line 64), and that prefix becomes **`restoreKey`** (line 121)
- **`cacheKey`** is then `restoreKey` with the lockfile hash appended (line 246)

The split is deliberate. On a dependency change the exact `cacheKey` misses, `restoreKey` still hits, and the job restores the previous cache and rebuilds only what actually moved.

Putting `CARGO_LOCK_SHA` inside `shared-key` puts the lockfile on **both** keys. Every dependency bump then misses both, and `lint`, `build` and `test coverage` each do a fully cold build. Dependabot opens cargo bumps here most weeks, so this is a routine cost rather than a rare one.

## What this changes

Drop the `Cargo.lock` SHA and let rust-cache append the lockfile hash itself, which it already does.

Drop the rust version too, as redundant rather than harmful: `restoreKey`'s digest already hashes rustc release, host and commit hash, along with the `CARGO`, `CC`, `CFLAGS`, `CXX`, `CMAKE` and `RUST` prefixed environment variables. Coverage on nightly therefore keeps a separate cache from the stable jobs without this action having to say so.

Neither environment variable is referenced anywhere else in the repository, so the two steps that computed them go with them.

## Measurement

Unlike the coverage change, this one is **unmeasured**. The effect appears only on PRs that change `Cargo.lock`, so it shows up in the spread rather than the median, and it needs a dependabot PR to land before it is visible. I did not want to overstate it: the mechanism is confirmed from the action's source, the size is not.

## Noticed but not changed

This composite pins `Swatinem/rust-cache` at v2.8.0 while `deps` and `security audit` pin v2.9.2 in the same workflow. Worth reconciling separately.
