### PR TITLE
fix: allow a manifest entry to declare no permissions

### DIFF
--- a/.config/_typos.toml
+++ b/.config/_typos.toml
@@ -12,3 +12,6 @@ extend-exclude = [
 Wass = "Wass"
 # CSS variable name in docs/theme/toc.css
 existant = "existant"
+# Deliberate misspelling of `network`, used by a manifest validation test to prove
+# that an unknown permission key is rejected rather than silently discarded.
+netwrok = "netwrok"

--- a/crates/wassette-mcp-server/src/manifest.rs
+++ b/crates/wassette-mcp-server/src/manifest.rs
@@ -40,7 +40,11 @@ pub struct ComponentDeclaration {
 }
 
 /// Inline permission declarations (only mode supported in MVP)
+///
+/// Unknown keys are rejected so that a mistyped or misindented permission key
+/// fails loudly instead of being discarded into an empty declaration.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct InlinePermissions {
     /// Network permissions
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -260,14 +264,14 @@ impl ComponentDeclaration {
 impl InlinePermissions {
     /// Validate inline permissions
     pub fn validate(&self) -> Result<()> {
-        // At least one permission type should be specified
-        if self.network.is_none()
-            && self.storage.is_none()
-            && self.environment.is_none()
-            && self.resources.is_none()
-        {
-            bail!("Inline permissions must specify at least one permission type (network, storage, environment, or resources)");
-        }
+        // An empty declaration (`permissions: {}`, or a bare `permissions:`, which YAML
+        // reads as null) is legal. It does not clear the component's capabilities:
+        // provisioning skips policy synthesis for it, so the component keeps whatever
+        // policy is already on disk,
+        // including one written by an earlier interactive grant or shipped by the artifact.
+        // `deny_unknown_fields` on the struct is what keeps a mistyped key from silently
+        // becoming an empty declaration, and the field stays required so that omitting
+        // `permissions:` entirely is still an error.
 
         // Validate network permissions
         if let Some(network) = &self.network {
@@ -456,7 +460,7 @@ components:
     }
 
     #[test]
-    fn test_empty_inline_permissions() {
+    fn test_empty_inline_permissions_is_valid() {
         let yaml = r#"
 version: 1
 components:
@@ -465,7 +469,105 @@ components:
 "#;
 
         let manifest = ProvisioningManifest::from_yaml(yaml).unwrap();
-        assert!(manifest.validate().is_err());
+        manifest.validate().unwrap();
+
+        let permissions = &manifest.components[0].permissions;
+        assert!(permissions.network.is_none());
+        assert!(permissions.storage.is_none());
+        assert!(permissions.environment.is_none());
+        assert!(permissions.resources.is_none());
+    }
+
+    #[test]
+    fn test_empty_inline_permissions_validate_directly() {
+        let permissions = InlinePermissions {
+            network: None,
+            storage: None,
+            environment: None,
+            resources: None,
+        };
+
+        permissions.validate().unwrap();
+    }
+
+    #[test]
+    fn test_bare_permissions_key_matches_empty_map() {
+        let yaml = r#"
+version: 1
+components:
+  - uri: oci://example.com/component:latest
+    permissions:
+"#;
+
+        let manifest = ProvisioningManifest::from_yaml(yaml)
+            .expect("a bare `permissions:` key is YAML null and parses as an empty declaration");
+        manifest.validate().unwrap();
+
+        let permissions = &manifest.components[0].permissions;
+        assert!(permissions.network.is_none());
+        assert!(permissions.storage.is_none());
+        assert!(permissions.environment.is_none());
+        assert!(permissions.resources.is_none());
+    }
+
+    #[test]
+    fn test_misspelled_permission_key_is_rejected() {
+        let yaml = r#"
+version: 1
+components:
+  - uri: oci://example.com/component:latest
+    permissions:
+      netwrok:
+        allow:
+          - host: api.example.com
+"#;
+
+        let error = ProvisioningManifest::from_yaml(yaml)
+            .expect_err("a misspelled permission key must fail to parse");
+        // Assert on the concepts rather than serde's exact phrasing, so that a
+        // reworded upstream message does not fail a test whose behaviour still holds.
+        let message = format!("{error:#}").to_lowercase();
+        assert!(
+            message.contains("unknown") && message.contains("netwrok"),
+            "expected an unknown-field error naming `netwrok`, got: {message}"
+        );
+    }
+
+    #[test]
+    fn test_misindented_allow_is_rejected() {
+        let yaml = r#"
+version: 1
+components:
+  - uri: oci://example.com/component:latest
+    permissions:
+      allow:
+        - host: api.example.com
+"#;
+
+        let error = ProvisioningManifest::from_yaml(yaml)
+            .expect_err("an `allow` key directly under `permissions` must fail to parse");
+        let message = format!("{error:#}").to_lowercase();
+        assert!(
+            message.contains("unknown") && message.contains("allow"),
+            "expected an unknown-field error naming `allow`, got: {message}"
+        );
+    }
+
+    #[test]
+    fn test_missing_permissions_field_is_parse_error() {
+        let yaml = r#"
+version: 1
+components:
+  - uri: oci://example.com/component:latest
+"#;
+
+        let error = ProvisioningManifest::from_yaml(yaml)
+            .expect_err("a component without a permissions field must fail to parse");
+        let message = format!("{error:#}").to_lowercase();
+        assert!(
+            message.contains("missing") && message.contains("permissions"),
+            "expected a missing-field error naming `permissions`, got: {message}"
+        );
     }
 
     #[test]

--- a/crates/wassette-mcp-server/tests/cli_integration_test.rs
+++ b/crates/wassette-mcp-server/tests/cli_integration_test.rs
@@ -214,8 +214,17 @@ async fn test_serve_manifest_attaches_declared_policy() -> Result<()> {
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_serve_manifest_resources_only_preserves_existing_policy() -> Result<()> {
+/// Shared body for the manifest provisioning regression tests.
+///
+/// Loads the fetch component, grants it a network permission interactively, then
+/// starts `serve --manifest` with a manifest whose permissions block synthesises
+/// no policy, and asserts that the interactive grant survived provisioning.
+/// `permissions_block` is the indented `permissions:` mapping for the single
+/// component entry, including its trailing newline.
+async fn assert_manifest_preserves_existing_policy(
+    permissions_block: &str,
+    granted_host: &str,
+) -> Result<()> {
     let ctx = CliTestContext::new().await?;
     let component_path = build_fetch_component().await?;
     let (stdout, stderr, exit_code) = ctx
@@ -229,7 +238,6 @@ async fn test_serve_manifest_resources_only_preserves_existing_policy() -> Resul
 
     let load_output: Value = ctx.parse_json_output(&stdout)?;
     let component_id = load_output["id"].as_str().context("Missing component ID")?;
-    let granted_host = "preserved.example.com";
     let (_, stderr, exit_code) = ctx
         .run_command(&["permission", "grant", "network", component_id, granted_host])
         .await?;
@@ -248,7 +256,7 @@ async fn test_serve_manifest_resources_only_preserves_existing_policy() -> Resul
     tokio::fs::write(
         &manifest_path,
         format!(
-            "version: 1\ncomponents:\n  - uri: file://{}\n    permissions:\n      resources:\n        memory_bytes: 67108864\n",
+            "version: 1\ncomponents:\n  - uri: file://{}\n{permissions_block}",
             component_path.display()
         ),
     )
@@ -274,7 +282,9 @@ async fn test_serve_manifest_resources_only_preserves_existing_policy() -> Resul
     let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         if let Some(status) = child.try_wait()? {
-            anyhow::bail!("wassette serve exited before becoming ready: {status}");
+            anyhow::bail!(
+                "wassette serve exited before becoming ready with permissions block {permissions_block:?}: {status}"
+            );
         }
         if TcpStream::connect(bind_address).await.is_ok() {
             break;
@@ -295,6 +305,24 @@ async fn test_serve_manifest_resources_only_preserves_existing_policy() -> Resul
     );
 
     Ok(())
+}
+
+#[test(tokio::test)]
+async fn test_serve_manifest_resources_only_preserves_existing_policy() -> Result<()> {
+    assert_manifest_preserves_existing_policy(
+        "    permissions:\n      resources:\n        memory_bytes: 67108864\n",
+        "preserved.example.com",
+    )
+    .await
+}
+
+#[test(tokio::test)]
+async fn test_serve_manifest_empty_permissions_preserves_existing_policy() -> Result<()> {
+    assert_manifest_preserves_existing_policy(
+        "    permissions: {}\n",
+        "preserved-empty.example.com",
+    )
+    .await
 }
 
 #[test(tokio::test)]


### PR DESCRIPTION
## Summary

A manifest entry must declare at least one permission type, so there is no way to say "this component needs nothing". A component that legitimately requires no capabilities cannot be provisioned through `serve --manifest` at all.

This is not a corner case. Three of this repository's own examples are in that class, and one of them, `memory-js`, ships a `policy.yaml` whose entire permissions block is `permissions: {}`, which is exactly the spelling the manifest validator rejects.

It matters most in a hardened headless deployment. `--disable-builtin-tools` removes `load-component`, so a running server cannot be handed a component at runtime and `--manifest` is the declarative way in. The remaining alternative is to pre-populate `--component-dir` out of band, since `serve` always loads what is already there, but that gives up the manifest as the description of what the server runs. Validation failure is fatal, so the server exits non-zero rather than starting degraded, which under a supervisor is a restart loop rather than a degraded server.

## Before

```yaml
version: 1
components:
  - uri: oci://ghcr.io/microsoft/time-server-js:latest
    name: timeserver
    permissions: {}
```

```
Error: Manifest validation failed

Caused by:
    0: Invalid component at index 0
    1: Invalid permissions configuration
```

## The change

Drop the check in `InlinePermissions::validate` that required one of `network`, `storage`, `environment` or `resources` to be present.

`permissions` stays a required field, so omitting it entirely still fails to parse with
serde's ``missing field `permissions` ``. An explicit empty map (`permissions: {}`) and
a bare `permissions:` key are both accepted as empty declarations.

Removing the arity check would otherwise turn misspelled permission keys into empty
declarations because serde ignores unknown fields by default. Add
`#[serde(deny_unknown_fields)]` to `InlinePermissions`, so a typo such as `netwrok:` or
a misindented `allow:` fails to parse and names the unknown field. This keeps the typo
guard while making deliberately empty declarations legal.

## Why this is safe

Provisioning already handles "there is nothing to synthesize". `has_synthesizable_permissions` returns false when `network`, `storage` and `environment` are all `None`, so the synthesize-and-attach block is skipped: no staging file, no `attach_policy`, no metadata write. The component is already loaded at that point, so it registers and exposes its tools, and `restore_from_disk` rehydrates any policy already on disk untouched.

An empty declaration therefore takes the identical branch a `resources`-only declaration already takes, the one added in #777 precisely to avoid overwriting an interactive grant with an empty document. This change adds no policy attachment behaviour of its own; it only changes which manifests parse.

## Tests

- Invert the previous unit test that asserted an empty declaration was invalid.
- Pin omission of the required `permissions` field as a parse error.
- Assert that a misspelled permission key and a misindented `allow:` both fail with
  `unknown field`.
- Assert that `permissions:` and `permissions: {}` produce the same empty declaration.
- Provision an empty declaration end to end, assert the server starts, and verify that an
  existing interactive network grant survives in the on-disk policy.