### PR TITLE
fix(errors): keep the cause of a component load failure visible

### DIFF
--- a/crates/mcp-server/src/components.rs
+++ b/crates/mcp-server/src/components.rs
@@ -3,14 +3,14 @@
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use futures::stream::{self, StreamExt};
 use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock, Tool};
 use rmcp::{Peer, RoleServer};
 use serde_json::{json, Value};
 use tracing::{debug, error, info, instrument};
 use wassette::schema::{canonicalize_output_schema, ensure_structured_result};
-use wassette::{ComponentLoadOutcome, LifecycleManager, LoadResult};
+use wassette::{format_error_chain, ComponentLoadOutcome, LifecycleManager, LoadResult};
 
 #[instrument(skip(lifecycle_manager))]
 pub(crate) async fn get_component_tools(lifecycle_manager: &LifecycleManager) -> Result<Vec<Tool>> {
@@ -69,17 +69,14 @@ pub(crate) async fn handle_load_component(
             create_load_component_success_result(&outcome)
         }
         Err(e) => {
+            let e = e.context(format!("Failed to load component: {path}"));
             error!(
                 path = %path,
                 operation = "load-component",
-                error = %e,
+                error = %format_error_chain(&e),
                 "Component load operation failed"
             );
-            Err(anyhow::anyhow!(
-                "Failed to load component: {}. Error: {}",
-                path,
-                e
-            ))
+            Err(e)
         }
     }
 }
@@ -116,7 +113,7 @@ pub(crate) async fn handle_unload_component(
             error!(
                 component_id = %id,
                 operation = "unload-component",
-                error = %e,
+                error = %format_error_chain(&e),
                 "Component unload operation failed"
             );
             Ok(create_component_error_result("unload", id, &e))
@@ -134,7 +131,7 @@ pub async fn handle_component_call(
     let component_id = lifecycle_manager
         .get_component_id_for_tool(&req.name)
         .await
-        .map_err(|e| anyhow::anyhow!("Failed to find component for tool '{}': {}", req.name, e))?;
+        .with_context(|| format!("Failed to find component for tool '{}'", req.name))?;
 
     debug!(
         function_name = %req.name,
@@ -181,10 +178,10 @@ pub async fn handle_component_call(
             error!(
                 function_name = %req.name,
                 component_id = %component_id,
-                error = %e,
+                error = %format_error_chain(&e),
                 "Component function invocation failed"
             );
-            Err(anyhow::anyhow!(e.to_string()))
+            Err(e)
         }
     }
 }
@@ -332,7 +329,7 @@ fn create_component_error_result(
 ) -> CallToolResult {
     let error_text = serde_json::to_string(&json!({
         "status": "error",
-        "message": format!("Failed to {} component: {}", operation_name, error),
+        "message": format!("Failed to {} component: {}", operation_name, format_error_chain(error)),
         "id": operation_arg
     }))
     .unwrap_or_else(|_| {
@@ -384,12 +381,9 @@ pub async fn handle_load_component_cli(
             create_load_component_success_result(&outcome)
         }
         Err(e) => {
-            error!(error = %e, path, "Failed to load component");
-            Err(anyhow::anyhow!(
-                "Failed to load component: {}. Error: {}",
-                path,
-                e
-            ))
+            let e = e.context(format!("Failed to load component: {path}"));
+            error!(error = %format_error_chain(&e), path, "Failed to load component");
+            Err(e)
         }
     }
 }
@@ -414,7 +408,7 @@ pub async fn handle_unload_component_cli(
             create_component_success_result("unload", id)
         }
         Err(e) => {
-            error!(error = %e, "Failed to unload component");
+            error!(error = %format_error_chain(&e), "Failed to unload component");
             Ok(create_component_error_result("unload", id, &e))
         }
     }

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -6,12 +6,12 @@ use std::cmp::Reverse;
 use std::sync::Arc;
 use std::time::Instant;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock, Tool};
 use rmcp::{Peer, RoleServer};
 use serde_json::{json, Value};
 use tracing::{debug, error, info, instrument, warn};
-use wassette::LifecycleManager;
+use wassette::{format_error_chain, LifecycleManager};
 
 use crate::components::{
     extract_args_from_request, get_component_tools, handle_component_call, handle_list_components,
@@ -192,7 +192,7 @@ pub async fn handle_tools_call(
                 tool_name = %tool_name,
                 duration_ms = %duration.as_millis(),
                 outcome = "error",
-                error = %e,
+                error = %format_error_chain(e),
                 "Tool invocation failed"
             );
         }
@@ -201,7 +201,7 @@ pub async fn handle_tools_call(
     match result {
         Ok(result) => Ok(serde_json::to_value(result)?),
         Err(e) => {
-            let error_text = format!("Error: {e}");
+            let error_text = format!("Error: {}", format_error_chain(&e));
             let contents = vec![ContentBlock::text(error_text)];
 
             let error_result = CallToolResult::error(contents);
@@ -623,7 +623,7 @@ pub async fn handle_get_policy(
     lifecycle_manager
         .ensure_component_loaded(component_id)
         .await
-        .map_err(|e| anyhow::anyhow!("Component not found: {} ({})", component_id, e))?;
+        .with_context(|| format!("Component not found: {component_id}"))?;
 
     let policy_info = lifecycle_manager.get_policy_info(component_id).await;
 
@@ -678,7 +678,7 @@ async fn handle_grant_permission_generic(
     lifecycle_manager
         .ensure_component_loaded(component_id)
         .await
-        .map_err(|e| anyhow::anyhow!("Component not found: {} ({})", component_id, e))?;
+        .with_context(|| format!("Component not found: {component_id}"))?;
 
     let result = lifecycle_manager
         .grant_permission(component_id, permission_type, details)
@@ -776,7 +776,7 @@ async fn handle_revoke_permission_generic(
     lifecycle_manager
         .ensure_component_loaded(component_id)
         .await
-        .map_err(|e| anyhow::anyhow!("Component not found: {} ({})", component_id, e))?;
+        .with_context(|| format!("Component not found: {component_id}"))?;
 
     let result = lifecycle_manager
         .revoke_permission(component_id, permission_type, details)
@@ -839,7 +839,7 @@ pub async fn handle_revoke_storage_permission(
     lifecycle_manager
         .ensure_component_loaded(component_id)
         .await
-        .map_err(|e| anyhow::anyhow!("Component not found: {} ({})", component_id, e))?;
+        .with_context(|| format!("Component not found: {component_id}"))?;
 
     let result = lifecycle_manager
         .revoke_storage_permission_by_uri(component_id, uri)
@@ -908,7 +908,7 @@ pub async fn handle_reset_permission(
     lifecycle_manager
         .ensure_component_loaded(component_id)
         .await
-        .map_err(|e| anyhow::anyhow!("Component not found: {} ({})", component_id, e))?;
+        .with_context(|| format!("Component not found: {component_id}"))?;
 
     let result = lifecycle_manager.reset_permission(component_id).await;
 

--- a/crates/wassette-mcp-server/src/main.rs
+++ b/crates/wassette-mcp-server/src/main.rs
@@ -144,7 +144,7 @@ async fn main() -> Result<()> {
                         .load_existing_components_async(None, Some(notify_fn))
                         .await
                     {
-                        tracing::error!("Background component loading failed: {}", e);
+                        tracing::error!("Background component loading failed: {:#}", e);
                     }
                 });
 
@@ -255,7 +255,7 @@ async fn main() -> Result<()> {
                         .load_existing_components_async(None, Some(notify_fn))
                         .await
                     {
-                        tracing::error!("Background component loading failed: {}", e);
+                        tracing::error!("Background component loading failed: {:#}", e);
                     }
                 });
 
@@ -795,7 +795,7 @@ async fn main() -> Result<()> {
                                 }
                             }
                             Err(e) => {
-                                eprintln!("Error invoking tool '{}': {}", name, e);
+                                eprintln!("Error invoking tool '{}': {:#}", name, e);
                                 std::process::exit(1);
                             }
                         }

--- a/crates/wassette-mcp-server/src/provisioning_controller.rs
+++ b/crates/wassette-mcp-server/src/provisioning_controller.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
-use wassette::{LifecycleManager, SecretsManager};
+use wassette::{format_error_chain, LifecycleManager, SecretsManager};
 
 use crate::manifest::{ComponentDeclaration, InlinePermissions, ProvisioningManifest};
 use crate::permission_synthesis;
@@ -55,7 +55,11 @@ impl<'a> ProvisioningController<'a> {
             );
 
             if let Err(e) = self.provision_component(component).await {
-                tracing::error!("Failed to provision component {}: {}", component_name, e);
+                tracing::error!(
+                    "Failed to provision component {}: {}",
+                    component_name,
+                    format_error_chain(&e)
+                );
                 errors.push((component_name.to_string(), e));
             }
         }
@@ -63,7 +67,7 @@ impl<'a> ProvisioningController<'a> {
         if !errors.is_empty() {
             let error_summary = errors
                 .iter()
-                .map(|(name, e)| format!("  - {}: {}", name, e))
+                .map(|(name, e)| format!("  - {}: {}", name, format_error_chain(e)))
                 .collect::<Vec<_>>()
                 .join("\n");
 

--- a/crates/wassette/src/error_display.rs
+++ b/crates/wassette/src/error_display.rs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Helpers for rendering [`anyhow::Error`] values for human consumption.
+
+/// Renders an error together with its full source chain on a single line.
+///
+/// `anyhow`'s default [`Display`](std::fmt::Display) implementation prints only
+/// the outermost message and silently drops every source added with
+/// [`Context`](anyhow::Context). The alternate form (`{:#}`) joins the whole
+/// chain as `outer: inner: innermost`, which keeps the root cause visible on
+/// user-facing surfaces such as the CLI, MCP tool results and tracing output.
+///
+/// This is generic over [`Display`](std::fmt::Display) so it applies equally to
+/// [`anyhow::Error`] and [`wasmtime::Error`], which is a distinct type with the
+/// same alternate-form behaviour.
+pub fn format_error_chain<E>(error: &E) -> String
+where
+    E: std::fmt::Display + ?Sized,
+{
+    format!("{error:#}")
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::anyhow;
+
+    use super::format_error_chain;
+
+    /// Mirrors the error chain produced by `LifecycleManager::load_component`
+    /// when a component imports an interface the linker does not provide.
+    fn load_component_error() -> anyhow::Error {
+        anyhow!("function implementation is missing")
+            .context("instance export `get` has the wrong type")
+            .context(
+                "component imports instance `wasi:config/store@0.2.0-draft`, but a matching \
+                 implementation was not found in the linker",
+            )
+            .context(
+                "Failed to compile component from path: /tmp/component.wasm. Please ensure the \
+                 file is a valid WebAssembly component.",
+            )
+            .context("Failed to load component: oci://ghcr.io/microsoft/get-weather-js:latest")
+    }
+
+    #[test]
+    fn plain_display_drops_the_source_chain() {
+        // This is the bug the helper exists to prevent: `{}` renders only the
+        // outermost context.
+        let rendered = format!("{}", load_component_error());
+        assert_eq!(
+            rendered,
+            "Failed to load component: oci://ghcr.io/microsoft/get-weather-js:latest"
+        );
+        assert!(!rendered.contains("not found in the linker"));
+    }
+
+    #[test]
+    fn format_error_chain_keeps_the_outer_context() {
+        let rendered = format_error_chain(&load_component_error());
+        assert!(
+            rendered.starts_with(
+                "Failed to load component: oci://ghcr.io/microsoft/get-weather-js:latest"
+            ),
+            "outer context must be preserved, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn format_error_chain_reaches_the_innermost_cause() {
+        let rendered = format_error_chain(&load_component_error());
+        assert!(
+            rendered.contains("wasi:config/store@0.2.0-draft"),
+            "missing failing import, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("not found in the linker"),
+            "missing linker cause, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("instance export `get` has the wrong type"),
+            "missing intermediate cause, got: {rendered}"
+        );
+        assert!(
+            rendered.ends_with("function implementation is missing"),
+            "innermost message must reach the user, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn format_error_chain_renders_on_a_single_line() {
+        let rendered = format_error_chain(&load_component_error());
+        assert!(
+            !rendered.contains('\n'),
+            "chain must stay on one line, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn format_error_chain_handles_a_bare_error() {
+        let rendered = format_error_chain(&anyhow!("no sources here"));
+        assert_eq!(rendered, "no sources here");
+    }
+}

--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -28,6 +28,7 @@ use wasmtime::Store;
 
 mod component_storage;
 mod config;
+mod error_display;
 mod http;
 mod loader;
 pub mod oci_multi_layer;
@@ -39,6 +40,7 @@ mod wasistate;
 
 use component_storage::ComponentStorage;
 pub use config::{LifecycleBuilder, LifecycleConfig};
+pub use error_display::format_error_chain;
 pub use http::WassetteWasiState;
 use loader::{ComponentResource, DownloadedResource};
 use policy_internal::PolicyManager;
@@ -500,7 +502,7 @@ impl LifecycleManager {
                 .save_component_metadata(component_id, &tool_metadata, validation_stamp)
                 .await
             {
-                warn!(%component_id, error = %e, "Failed to save component metadata");
+                warn!(%component_id, error = %format_error_chain(&e), "Failed to save component metadata");
             }
         }
 
@@ -510,7 +512,7 @@ impl LifecycleManager {
             .await?;
 
         if let Err(error) = self.policy_manager.restore_from_disk(component_id).await {
-            warn!(%component_id, %error, "Failed to restore policy attachment");
+            warn!(%component_id, error = %format_error_chain(&error), "Failed to restore policy attachment");
         }
 
         Ok(ComponentLoadOutcome {
@@ -918,7 +920,7 @@ impl LifecycleManager {
                     return Ok((component, wasm_bytes));
                 }
                 Err(e) => {
-                    warn!(%component_id, error = %e, "Failed to load precompiled component, falling back to compilation");
+                    warn!(%component_id, error = %format_error_chain(&e), "Failed to load precompiled component, falling back to compilation");
                 }
             }
         }
@@ -937,7 +939,7 @@ impl LifecycleManager {
             .save_precompiled_component(component_id, &wasm_bytes)
             .await
         {
-            warn!(%component_id, error = %e, "Failed to save precompiled component");
+            warn!(%component_id, error = %format_error_chain(&e), "Failed to save precompiled component");
         }
 
         debug!(component_id = %component_id, "Compiled component and saved to cache");
@@ -1146,7 +1148,7 @@ impl LifecycleManager {
                         }
                     }
                     Ok(false) => {} // No component to load (not a .wasm file)
-                    Err(e) => warn!("Failed to load component: {}", e),
+                    Err(e) => warn!("Failed to load component: {:#}", e),
                 }
             };
             load_futures.push(future);
@@ -1212,7 +1214,7 @@ impl LifecycleManager {
                             continue;
                         }
                         Err(e) => {
-                            warn!(%component_id, error = %e, "Failed to register tools from metadata");
+                            warn!(%component_id, error = %format_error_chain(&e), "Failed to register tools from metadata");
                             continue;
                         }
                     }
@@ -1301,7 +1303,7 @@ async fn load_components_parallel(
     for result in results.into_iter().flatten() {
         match result {
             Ok(component) => components.push(component),
-            Err(e) => warn!("Failed to load component: {}", e),
+            Err(e) => warn!("Failed to load component: {:#}", e),
         }
     }
 


### PR DESCRIPTION
Every surface that reports a component load failure discards the cause. This makes a precise
link error indistinguishable from a corrupt file.

## The bug

`LifecycleManager::load_component` builds a proper error chain with `.with_context(...)`.
Everything downstream then formats the `anyhow::Error` with `{}`, which prints only the
outermost message and silently drops every source:

- `handle_load_component` and `handle_load_component_cli` in
  `crates/mcp-server/src/components.rs` rebuild it as
  `anyhow!("Failed to load component: {}. Error: {}", path, e)`, so the sources are gone
  before either the server or the CLI prints anything.
- `create_component_error_result` does the same for the MCP tool result.
- `handle_tools_call` renders `format!("Error: {e}")`.
- The provisioning controller reduces it further, to
  `Failed to load component from URI: <uri>`.
- The `error = %e` tracing fields are `Display` too, so the logs lose it as well.

The component downloads, compiles and precompiles successfully before the failure, so
"Please ensure the file is a valid WebAssembly component" is not merely unhelpful. It points
away from the real fault.

## Before and after

Loading a component that imports an interface the linker does not provide. Before:

```
Error: Failed to load component: file:///tmp/get-weather-js.wasm. Error: Failed to compile
component from path: /tmp/.../get-weather-js.wasm. Please ensure the file is a valid
WebAssembly component.
```

After:

```
Error: Failed to load component: file:///tmp/get-weather-js.wasm

Caused by:
    0: Failed to compile component from path: /tmp/.../get-weather-js.wasm. Please ensure
       the file is a valid WebAssembly component.
    1: failed to instantiate component
    2: component imports instance `wasi:config/store@0.2.0-draft`, but a matching
       implementation was not found in the linker
    3: instance export `get` has the wrong type
    4: function implementation is missing
```

The MCP tool result carries the same chain, joined on one line.

## What changed

Two kinds of change:

1. Where an error was rebuilt with `anyhow::anyhow!` purely to add the URI or component id,
   the context is added to the original instead, so the chain survives rather than being
   flattened into a string.
2. Everywhere an error is rendered for a human, anyhow's alternate form is used, which joins
   the chain as `outer: inner: innermost`. That covers the CLI, the MCP tool result, the
   tracing output on both the server and CLI paths, and manifest provisioning.

`format_error_chain` in the new `wassette::error_display` gives this one documented home and
somewhere to hang tests, including one that pins the old behaviour: plain `{}` renders only
the outer context.

The existing outer messages are kept. The change is that what follows them is no longer
truncated.

## Verification

Reproduced against a real component that triggers the failure, with a freshly built binary,
on every surface that was losing the cause:

- `wassette component load` now prints all five `Caused by:` levels, ending at
  `function implementation is missing`.
- The `load-component` MCP tool result carries the same chain, joined on one line.
- `serve --manifest` carries it in both the per-component `ERROR` line and the final
  `Failed to provision 1 component(s)` summary. Previously that summary read
  `Failed to load component from URI: <uri>` and stopped there.
- A component that loads successfully is unchanged, and reports its tools as before.

`cargo test --workspace` passes: 25 suites, no failures, including five new tests on the
rendering helper, one of which pins the old behaviour. `cargo clippy --workspace
--all-targets -- -D warnings` and `cargo +nightly fmt --all --check` are both clean.