### PR TITLE
fix(ci): move :latest when examples are published from main

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -132,8 +132,12 @@ jobs:
               echo "release_tag=$INPUT_TAG" >> $GITHUB_OUTPUT
             fi
           else
+            # A push to main. Publish the SHA tag and move :latest onto it, so a
+            # merged fix to examples/ reaches anyone loading them by the URIs in
+            # component-registry.json, which are all :latest and carry no version.
             echo "tag=$GITHUB_SHA" >> $GITHUB_OUTPUT
-            echo "latest=false" >> $GITHUB_OUTPUT
+            echo "latest=true" >> $GITHUB_OUTPUT
+            echo "release_tag=latest" >> $GITHUB_OUTPUT
           fi
       - name: Publish ${{ matrix.component.name }}
         id: publish_versioned

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -293,19 +293,21 @@ The [`examples.yml`](.github/workflows/examples.yml) workflow automatically publ
 - A pull request targeting the `main` branch modifies files in the `examples/**` directory (build only, no publish)
 - The release workflow dispatches it with a version tag after publishing the binaries
 
-**Published examples include:**
+**Published examples** (the `publish` matrix in `examples.yml`):
+- `arxiv-rs` - arXiv paper search in Rust
+- `brave-search-rs` - Web search using Brave Search API
 - `eval-py` - Python expression evaluator
 - `fetch-rs` - HTTP fetch example in Rust
 - `filesystem-rs` - Filesystem operations in Rust
+- `get-open-meteo-weather-js` - Weather data via Open-Meteo API (no API key required)
 - `get-weather-js` - Weather API example in JavaScript using OpenWeather API
+- `github-js` - GitHub API client in JavaScript
 - `gomodule-go` - Go module information tool
 - `memory-js` - Knowledge graph memory server in JavaScript
 - `time-server-js` - Time server example in JavaScript
 
-**Additional examples in repository (not yet published to OCI registry):**
-- `brave-search-rs` - Web search using Brave Search API
+**Additional examples in repository (not published to OCI registry):**
 - `context7-rs` - Search libraries and fetch documentation via Context7 API
-- `get-open-meteo-weather-js` - Weather data via Open-Meteo API (no API key required)
 
 **What the workflow does:**
 1. Builds all example components using `just build-examples`
@@ -314,6 +316,16 @@ The [`examples.yml`](.github/workflows/examples.yml) workflow automatically publ
    - The commit SHA (e.g., `abc1234`)
    - The `latest` tag for main branch pushes
 4. Signs all published images using Cosign
+
+Because `component-registry.json` and the documentation reference examples by
+`:latest` with no version, moving that tag on a push to `main` is what makes a
+merged change to `examples/**` reach anyone loading them. Publishing only the
+commit SHA would leave the registry pointing at the previous build.
+
+Pre-releases are excluded. The `publish-examples` job in `release.yml` skips a
+version containing `-`, and the `publish` job here skips a dispatch whose `tag`
+input contains `-`, so a run dispatched with something like `v0.4.0-rc1` builds
+the examples and publishes nothing.
 
 ### Manual Release of Example Components
 


### PR DESCRIPTION
`RELEASE.md` already documents the intended behaviour:

> 3. Tags each component with both:
>    - The commit SHA (e.g., `abc1234`)
>    - The `latest` tag for main branch pushes

The workflow does not do that. On a push to `main`, `Determine tag` sets `latest=false`, so the `Publish ... with tag latest (if specified)` step is skipped and only the commit SHA is published.

`component-registry.json` and every copy-paste `load-component` line in the docs reference examples as `:latest` with no version, so a merged change to `examples/**` never reaches anyone until the next release dispatches this workflow with a version tag.

## The failure mode is quiet

The run is green, the `publish` job succeeds, and the two `:latest` steps show as skipped inside it. That looks identical to a successful publish unless you go and check the registry.

This was live. #781 fixed two example components that could not be loaded at all. It merged, published a correct artifact under its commit SHA, and left `oci://ghcr.io/microsoft/get-weather-js:latest` serving the broken build until the workflow was dispatched by hand:

```
$ wkg oci pull ghcr.io/microsoft/get-weather-js:latest
wasi:config/store@0.2.0-draft          # the build #781 fixed

$ wkg oci pull ghcr.io/microsoft/get-weather-js:70e8e97e6...
wasi:config/store@0.2.0-rc.1           # what that same run published
```

## The change

Set `latest=true` on the push path. That activates the existing `steps.meta.outputs.release_tag || 'latest'` fallback, which is unreachable today and only makes sense for this path. `release_tag=latest` is written explicitly so the intent is not carried by a fallback.

Release paths are unchanged. `Determine tag` now yields:

| event | input | tag | latest | release_tag |
| --- | --- | --- | --- | --- |
| `push` | none | `<sha>` | **true** | `latest` |
| `workflow_dispatch` | `latest` | `<sha>` | true | `latest` |
| `workflow_dispatch` | `v0.6.1` | `0.6.1` | true | `latest` |

Only the first row changes.

**Pre-releases stay excluded.** The `!contains(..., '-')` guard on `publish-examples` in `release.yml` and on the `publish` job here are both untouched, so a `v0.4.0-rc1` release still publishes no examples.

## Also

Corrects the published-examples list in `RELEASE.md` against the `publish` matrix. It omitted `arxiv-rs` and `github-js`, and listed `brave-search-rs` and `get-open-meteo-weather-js` as unpublished when both are in the matrix. `context7-rs` is the only example genuinely not published.