### PR TITLE
fix(examples): make the provisioning manifests usable as written, and document the format

### DIFF
--- a/docs/deployment/operations.md
+++ b/docs/deployment/operations.md
@@ -280,6 +280,9 @@ read-only tool set from every instance:
 wassette serve --streamable-http --manifest /etc/wassette/manifest.yaml --disable-builtin-tools
 ```
 
+See the [provisioning manifest reference](https://github.com/microsoft/wassette/blob/main/examples/manifests/README.md)
+for the format and complete examples.
+
 With `--disable-builtin-tools` the management plane (loading, unloading and
 permission grants) is rejected, so every instance keeps serving exactly the
 tools it was provisioned with and the instances stay equivalent.

--- a/examples/manifests/README.md
+++ b/examples/manifests/README.md
@@ -1,0 +1,47 @@
+# Provisioning manifests
+
+A provisioning manifest defines the components that Wassette loads at startup.
+Pass the YAML file to `wassette serve` with `--manifest`, for example:
+
+```bash
+wassette serve --manifest examples/manifests/simple.yaml
+```
+
+## Format
+
+The top level is a mapping with two required fields. `version` is the manifest
+schema version, and its only supported value is the integer `1`. `components`
+is a non-empty sequence of component declarations. Each component must have a
+unique `uri`.
+
+Every component declaration requires `uri` and `permissions`. The `uri` locates
+the component with an `oci://`, `file://`, `https://`, or `http://` URI.
+`permissions` is required even when the component needs no inline permission
+overrides, in which case use `permissions: {}`. The optional `name` identifies
+the component in logs. The optional `digest` is an expected SHA-256 digest in
+the form `sha256:` followed by 64 hexadecimal characters. The optional
+`retry_policy` accepts an attempt count and either an `exponential` backoff with
+`base_ms` or a `linear` backoff with `increment_ms`; retry handling is currently
+deferred.
+
+The required `permissions` mapping can contain optional `network`, `storage`,
+`environment`, and `resources` permission types. A network permission has a
+non-empty `allow` sequence of `host` values. A storage permission has a
+non-empty `allow` sequence whose entries pair an `fs://` `uri` with one or both
+of the `read` and `write` access types. An environment permission has a
+non-empty `allow` sequence of variable `key` values. Each environment entry can
+also set `value_from` to read the value from a differently named variable in
+the Wassette process environment. If `value_from` is omitted, Wassette reads
+the variable named by `key`. The optional `resources` permission accepts
+`memory_bytes` and `cpu_time_ms`, but resource limit enforcement is currently
+deferred.
+
+## Examples
+
+Start with [`simple.yaml`](simple.yaml), which shows the minimum practical
+manifest for a component that needs network access and an environment secret.
+[`multi-component.yaml`](multi-component.yaml) adds components with empty and
+storage permissions. [`with-secrets.yaml`](with-secrets.yaml) demonstrates
+explicit `value_from` mappings. [`production.yaml`](production.yaml)
+illustrates version and digest pinning with placeholder values that must be
+replaced before use.

--- a/examples/manifests/multi-component.yaml
+++ b/examples/manifests/multi-component.yaml
@@ -5,17 +5,14 @@ components:
     permissions:
       network:
         allow:
-          - host: api.openweathermap.com
+          - host: api.openweathermap.org
       environment:
         allow:
           - key: OPENWEATHER_API_KEY
 
-  - uri: oci://ghcr.io/microsoft/time-server:latest
+  - uri: oci://ghcr.io/microsoft/time-server-js:latest
     name: time-service
-    permissions:
-      network:
-        allow:
-          - host: worldtimeapi.org
+    permissions: {}
 
   - uri: oci://ghcr.io/microsoft/filesystem-rs:latest
     name: filesystem-service

--- a/examples/manifests/production.yaml
+++ b/examples/manifests/production.yaml
@@ -1,4 +1,5 @@
 version: 1
+# Replace the example version tags and digests with published values before use.
 components:
   - uri: oci://ghcr.io/microsoft/get-weather-js:1.2.3
     name: weather-service
@@ -6,16 +7,13 @@ components:
     permissions:
       network:
         allow:
-          - host: api.openweathermap.com
+          - host: api.openweathermap.org
       environment:
         allow:
           - key: OPENWEATHER_API_KEY
             value_from: OPENWEATHER_API_KEY
 
-  - uri: oci://ghcr.io/microsoft/time-server:2.0.1
+  - uri: oci://ghcr.io/microsoft/time-server-js:2.0.1
     name: time-service
     digest: sha256:fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321
-    permissions:
-      network:
-        allow:
-          - host: worldtimeapi.org
+    permissions: {}

--- a/examples/manifests/simple.yaml
+++ b/examples/manifests/simple.yaml
@@ -5,7 +5,7 @@ components:
     permissions:
       network:
         allow:
-          - host: api.openweathermap.com
+          - host: api.openweathermap.org
       environment:
         allow:
           - key: OPENWEATHER_API_KEY

--- a/examples/manifests/with-secrets.yaml
+++ b/examples/manifests/with-secrets.yaml
@@ -5,7 +5,7 @@ components:
     permissions:
       network:
         allow:
-          - host: api.openweathermap.com
+          - host: api.openweathermap.org
       environment:
         allow:
           - key: OPENWEATHER_API_KEY


### PR DESCRIPTION
in outline: the four manifests in examples/manifests/ are the only worked examples of the format wassette serve --manifest consumes, and the format is documented nowhere else. All four contained defects that stop a reader who copies them: a component that is not published (time-server, GHCR 403, now time-server-js), a host the component never calls (api.openweathermap.com against the component's own .org), and a grant that was vestigial (worldtimeapi.org on a component with no network access, now permissions: {}). The second commit adds a README for the directory and links it from docs/deployment/operations.md, since nothing in the repository referenced examples/manifests/ at all.