### PR TITLE
feat(registry): warn when two loaded components export the same tool name

### DIFF
--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -268,8 +268,45 @@ impl ComponentRegistryState {
         }
     }
 
+    /// Tool names in `tool_names` that an already-registered component exports, each
+    /// paired with the ids of the components that already export it.
+    fn find_tool_name_collisions(&self, tool_names: &[String]) -> Vec<(String, Vec<String>)> {
+        tool_names
+            .iter()
+            .filter_map(|tool_name| {
+                let existing = self.tool_map.get(tool_name)?;
+                let mut component_ids: Vec<String> = existing
+                    .iter()
+                    .map(|info| info.component_id.clone())
+                    .collect();
+                component_ids.dedup();
+                if component_ids.is_empty() {
+                    None
+                } else {
+                    Some((tool_name.clone(), component_ids))
+                }
+            })
+            .collect()
+    }
+
     fn register_tools_only(&mut self, component_id: &str, tools: Vec<ToolMetadata>) {
-        let mut tool_names = Vec::new();
+        let incoming_names: Vec<String> = tools
+            .iter()
+            .map(|tool| tool.normalized_name.clone())
+            .collect();
+
+        for (tool_name, existing_component_ids) in self.find_tool_name_collisions(&incoming_names) {
+            warn!(
+                %component_id,
+                %tool_name,
+                existing_components = %existing_component_ids.join(", "),
+                "Tool name collision: this tool name is already exported by another loaded \
+                 component. The tool cannot be called while both components are loaded; unload \
+                 one of them to make it callable again"
+            );
+        }
+
+        let mut tool_names = Vec::with_capacity(incoming_names.len());
 
         for tool_metadata in tools {
             let ToolMetadata {
@@ -1975,5 +2012,140 @@ permissions:
             .contains("Component not found"));
 
         Ok(())
+    }
+
+    fn tool_metadata(name: &str) -> ToolMetadata {
+        ToolMetadata {
+            identifier: FunctionIdentifier {
+                package_name: None,
+                interface_name: None,
+                function_name: name.to_string(),
+            },
+            normalized_name: name.to_string(),
+            schema: serde_json::json!({ "name": name }),
+        }
+    }
+
+    fn tool_metadatas(names: &[&str]) -> Vec<ToolMetadata> {
+        names.iter().copied().map(tool_metadata).collect()
+    }
+
+    #[test]
+    fn test_find_tool_name_collisions_reports_nothing_for_distinct_names() {
+        let mut state = ComponentRegistryState::default();
+        state.register_tools_only("weather", tool_metadatas(&["get-weather"]));
+
+        assert!(state
+            .find_tool_name_collisions(&["delete-file".to_string()])
+            .is_empty());
+    }
+
+    #[test]
+    fn test_find_tool_name_collisions_reports_incumbent_component() {
+        let mut state = ComponentRegistryState::default();
+        state.register_tools_only("get-weather-js", tool_metadatas(&["get-weather"]));
+
+        let collisions = state
+            .find_tool_name_collisions(&["get-weather".to_string(), "unique-tool".to_string()]);
+
+        assert_eq!(
+            collisions,
+            vec![(
+                "get-weather".to_string(),
+                vec!["get-weather-js".to_string()]
+            )]
+        );
+    }
+
+    #[test]
+    fn test_find_tool_name_collisions_ignores_component_reloading_itself() {
+        let mut state = ComponentRegistryState::default();
+        let names = ["get-weather", "get-forecast"];
+        state.register_tools_only("get-weather-js", tool_metadatas(&names));
+
+        // A reload evicts the previous registration before re-registering.
+        state.unregister_tools("get-weather-js");
+
+        let incoming: Vec<String> = names.iter().map(|name| name.to_string()).collect();
+        assert!(state.find_tool_name_collisions(&incoming).is_empty());
+    }
+
+    #[test]
+    fn test_find_tool_name_collisions_reports_every_incumbent() {
+        let mut state = ComponentRegistryState::default();
+        state.register_tools_only("filesystem-rs", tool_metadatas(&["delete-file"]));
+        state.register_tools_only("github-js", tool_metadatas(&["delete-file"]));
+
+        let collisions = state.find_tool_name_collisions(&["delete-file".to_string()]);
+
+        assert_eq!(
+            collisions,
+            vec![(
+                "delete-file".to_string(),
+                vec!["filesystem-rs".to_string(), "github-js".to_string()]
+            )]
+        );
+    }
+
+    /// Collects formatted tracing output so a test can assert on emitted events.
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl CapturedLogs {
+        fn contents(&self) -> String {
+            String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+        }
+    }
+
+    impl std::io::Write for CapturedLogs {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLogs {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    #[test]
+    fn test_register_tools_only_warns_on_collision() {
+        let logs = CapturedLogs::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .with_max_level(tracing::Level::WARN)
+            .with_writer(logs.clone())
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            let mut state = ComponentRegistryState::default();
+            state.register_tools_only("get-weather-js", tool_metadatas(&["get-weather"]));
+            assert!(!logs.contents().contains("Tool name collision"));
+
+            state.register_tools_only(
+                "get-open-meteo-weather-js",
+                tool_metadatas(&["get-weather"]),
+            );
+        });
+
+        let captured = logs.contents();
+        assert!(captured.contains("Tool name collision"), "{captured}");
+        assert!(
+            captured.contains("component_id=get-open-meteo-weather-js"),
+            "{captured}"
+        );
+        assert!(captured.contains("tool_name=get-weather"), "{captured}");
+        assert!(
+            captured.contains("existing_components=get-weather-js"),
+            "{captured}"
+        );
     }
 }

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -104,9 +104,25 @@ sequenceDiagram
 
 ### Function Naming
 
-Wassette converts WIT interface names into tool names by replacing colons and slashes with underscores. For example:
+How a function is exported determines its tool name.
+
+A function exported directly from a world has no enclosing interface, so it
+becomes a tool under its own unqualified name. For example, a world that
+declares `export get-weather: func(city: string) -> result<string, string>;`
+registers the tool `get-weather`.
+
+A function exported through an interface is qualified by that interface's full
+name. Wassette normalizes the name by lowercasing it and replacing colons,
+slashes, and dots with underscores; hyphens are preserved. For example:
 - WIT: `example:weather/weather-api#get-weather`
-- Tool name: `example_weather_weather_api_get_weather`
+- Tool name: `example_weather_weather-api_get-weather`
+
+The tool namespace is flat and global across every loaded component; it is not
+scoped per component. If two loaded components export the same tool name — as
+two world-level `get-weather` exports would — both are registered under that
+name, and Wassette logs a warning when the second one is registered. Calling
+the tool then fails with an error naming both components. Unload one of them to
+make the tool callable again.
 
 ## Policy and Capability Model
 


### PR DESCRIPTION
Two loaded components that export the same tool name are both registered under it, and
nothing reports the overlap until a call arrives and fails naming both. This warns once per
colliding name at registration, so the problem is visible when the manifest is provisioned
rather than when the tool is first used. Call-time behaviour is unchanged and nothing is
renamed or rejected.

## The problem

The tool namespace is flat and global across loaded components. `register_tools_only` appends
unconditionally:

```rust
self.tool_map
    .entry(normalized_name.clone())
    .or_default()
    .push(tool_info);
```

Provisioning then reports `Successfully provisioned all components`, `tools/list` advertises
the name once per component with both entries looking callable, and the first sign of trouble
is at call time:

```
Error: Failed to find component for tool 'get-weather': Multiple components found for
tool 'get-weather': microsoft_get-open-meteo-weather-js, microsoft_get-weather-js
```

That call-time behaviour is right: refusing an ambiguous call is better than picking a
component arbitrarily, and the message names both candidates, so it is enough to act on. What
is missing is any signal before it.

This is easy to hit rather than exotic. Two pairs of this repository's own examples collide:
`get-weather-js` and `get-open-meteo-weather-js` both export `get-weather`, and `filesystem-rs`
and `github-js` both export `delete-file`. `delete-file` is a name a filesystem component and a
repository-file component will both reach for, and `github-js` alone exports 95 tools. The
damage is bounded to the colliding name, which is the good news: with `filesystem-rs` and
`github-js` both loaded, `read-file` and `write-file` work normally and only `delete-file` is
dead.

Nothing today can report it. `register_tools_only` returns `()`, so it cannot signal a conflict
even in principle; its callers check only whether the same component id is already present; and
the provisioning controller receives a `ComponentLoadOutcome` that carries `tool_names` and
uses only `.component_id`. The one duplicate check in the manifest layer is for URIs.

## The change

`ComponentRegistryState::find_tool_name_collisions` returns each incoming tool name an
already-registered component exports, paired with the incumbent component ids.
`register_tools_only` runs it before any insertion and emits one `warn!` per colliding name:

```
WARN wassette: Tool name collision: this tool name is already exported by another loaded
component. The tool cannot be called while both components are loaded; unload one of them to
make it callable again
  component_id=microsoft_get-open-meteo-weather-js tool_name=get-weather
  existing_components=microsoft_get-weather-js
```

`register_tools_only` is the site rather than a caller for two reasons. It is the single
funnel, so one check covers both the compile path through `upsert_component` and the
cached-metadata fast-start path through `register_metadata_if_absent`. And in the upsert case
it runs after `unregister_tools(&component_id)`, so a component reloading over itself has
already been evicted and does not warn about itself.

A warning rather than a rejection is deliberate. Loading a colliding component staying
non-fatal is an existing tested contract: `transport_integration_test.rs` loads a second copy
of `fetch-rs`, asserts the load succeeds, and asserts only the call fails. That test passes
unchanged. Rejection would also be awkward here, because `upsert_component` has already
unregistered the previous tools by the time `register_tools_only` runs, so failing midway would
leave the registry short.

## Documentation

`docs/concepts.md` had the only description of tool naming, and it was wrong twice. It
documented only the interface-export case, giving no hint that a function exported directly
from a world gets a bare unqualified name, which is the shape most of the examples here use and
the shape that collides. And its worked example converted hyphens to underscores when
`normalize_name_component` preserves them, so `example:weather/weather-api#get-weather` maps to
`example_weather_weather-api_get-weather` rather than `example_weather_weather_api_get_weather`.

Both are corrected, and a short paragraph now states that the namespace is flat and global
across loaded components and what happens when two components export the same name.

## Tests

Five unit tests in `crates/wassette/src/lib.rs`: distinct names report nothing, a second
component reports the incumbent, a component re-registering after `unregister_tools` reports
nothing, three components on one name report both incumbents, and a scoped `tracing` subscriber
asserts the warning is actually emitted with its fields. The last one captures through
`tracing_subscriber::fmt` with `with_default` rather than the `tracing-test` macro, because
`#[traced_test]` calls `set_global_default` and panics once another test has installed a global
subscriber. No new dependencies.

`cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets` and `cargo machete` are
clean, `cargo test -p wassette --lib` is 103 passed, and
`cargo build --workspace` succeeds. The OCI and HTTPS integration tests were not run for want
of a registry and network in the development environment; the change adds a log line and does
not alter the observable MCP surface.