### PR TITLE
fix(schema): preserve cached tool metadata during startup

### DIFF
--- a/crates/wassette-mcp-server/src/main.rs
+++ b/crates/wassette-mcp-server/src/main.rs
@@ -834,9 +834,7 @@ async fn main() -> Result<()> {
 
                 // Display tools information
                 if let Some(arr) = schema["tools"].as_array() {
-                    for t in arr {
-                        // The tool info is nested in properties.result
-                        let tool_info = &t["properties"]["result"];
+                    for tool_info in arr {
                         let name = tool_info["name"]
                             .as_str()
                             .unwrap_or("<unnamed>")

--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -744,6 +744,13 @@ impl LifecycleManager {
         // Fallback to metadata-based schema without compiling the component
         match self.load_component_metadata(component_id).await {
             Ok(Some(metadata)) => {
+                let component_path = self.component_path(component_id);
+                if !ComponentStorage::validate_stamp(&component_path, &metadata.validation_stamp)
+                    .await
+                {
+                    return None;
+                }
+
                 let tools: Vec<Value> = metadata
                     .tool_schemas
                     .into_iter()
@@ -1661,7 +1668,13 @@ mod tests {
                 },
                 "required": ["value"]
             },
-            "outputSchema": {"type": "string"}
+            "outputSchema": {
+                "type": "object",
+                "properties": {
+                    "result": {"type": "string"}
+                },
+                "required": ["result"]
+            }
         });
         let metadata = ComponentMetadata {
             component_id: component_id.to_string(),
@@ -1705,6 +1718,9 @@ mod tests {
         manager.populate_registry_from_metadata().await?;
         let registered_tools = manager.list_tools().await;
         assert_eq!(registered_tools, vec![cached_tool.clone()]);
+
+        tokio::fs::write(&component_path, b"changed component").await?;
+        assert!(manager.get_component_schema(component_id).await.is_none());
 
         Ok(())
     }

--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -747,7 +747,7 @@ impl LifecycleManager {
                 let tools: Vec<Value> = metadata
                     .tool_schemas
                     .into_iter()
-                    .map(|schema| schema::canonicalize_output_schema(&schema))
+                    .map(|schema| schema::canonicalize_tool_schema(&schema))
                     .collect();
                 Some(serde_json::json!({
                     "tools": tools
@@ -1227,7 +1227,7 @@ impl LifecycleManager {
                         .zip(metadata.tool_schemas)
                         .zip(metadata.tool_names)
                         .map(|((identifier, schema), normalized_name)| {
-                            let canonical = schema::canonicalize_output_schema(&schema);
+                            let canonical = schema::canonicalize_tool_schema(&schema);
                             ToolMetadata {
                                 identifier,
                                 schema: canonical,
@@ -1641,6 +1641,71 @@ mod tests {
         let actual_path = manager.component_path(component_id);
 
         assert_eq!(actual_path, expected_path);
+        Ok(())
+    }
+
+    #[test(tokio::test)]
+    async fn test_cached_tool_schema_preserves_tool_fields() -> Result<()> {
+        let manager = create_test_manager().await?;
+        let component_id = "cached-component";
+        let component_path = manager.component_path(component_id);
+        tokio::fs::write(&component_path, b"cached component").await?;
+
+        let tool_schema = serde_json::json!({
+            "name": "cached-tool",
+            "description": "A cached tool",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "value": {"type": "string"}
+                },
+                "required": ["value"]
+            },
+            "outputSchema": {"type": "string"}
+        });
+        let metadata = ComponentMetadata {
+            component_id: component_id.to_string(),
+            tool_schemas: vec![tool_schema],
+            function_identifiers: vec![FunctionIdentifier {
+                package_name: None,
+                interface_name: None,
+                function_name: "cached-tool".to_string(),
+            }],
+            tool_names: vec!["cached-tool".to_string()],
+            validation_stamp: manager
+                .storage
+                .create_validation_stamp(&component_path, false)
+                .await?,
+            created_at: 0,
+        };
+        manager.storage.write_metadata(&metadata).await?;
+
+        let component_schema = manager
+            .get_component_schema(component_id)
+            .await
+            .context("cached component schema should be available")?;
+        let cached_tool = &component_schema["tools"][0];
+        assert_eq!(cached_tool["name"], "cached-tool");
+        assert_eq!(cached_tool["description"], "A cached tool");
+        assert_eq!(
+            cached_tool["inputSchema"],
+            metadata.tool_schemas[0]["inputSchema"]
+        );
+        assert_eq!(
+            cached_tool["outputSchema"],
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "result": {"type": "string"}
+                },
+                "required": ["result"]
+            })
+        );
+
+        manager.populate_registry_from_metadata().await?;
+        let registered_tools = manager.list_tools().await;
+        assert_eq!(registered_tools, vec![cached_tool.clone()]);
+
         Ok(())
     }
 

--- a/crates/wassette/src/schema.rs
+++ b/crates/wassette/src/schema.rs
@@ -5,6 +5,23 @@
 
 use serde_json::{Map, Value};
 
+/// Canonicalize the output schema in a complete tool schema while preserving
+/// the tool's name, description, and input schema.
+pub fn canonicalize_tool_schema(tool_schema: &Value) -> Value {
+    let Value::Object(mut tool) = tool_schema.clone() else {
+        return tool_schema.clone();
+    };
+
+    if let Some(output_schema) = tool.get("outputSchema") {
+        tool.insert(
+            "outputSchema".to_string(),
+            canonicalize_output_schema(output_schema),
+        );
+    }
+
+    Value::Object(tool)
+}
+
 /// Canonicalize a tool output schema so that it always represents structured
 /// data as an object with a required `result` property.
 pub fn canonicalize_output_schema(schema: &Value) -> Value {

--- a/crates/wassette/src/schema.rs
+++ b/crates/wassette/src/schema.rs
@@ -12,7 +12,10 @@ pub fn canonicalize_tool_schema(tool_schema: &Value) -> Value {
         return tool_schema.clone();
     };
 
-    if let Some(output_schema) = tool.get("outputSchema") {
+    if let Some(output_schema) = tool
+        .get("outputSchema")
+        .filter(|output_schema| !output_schema.is_null())
+    {
         tool.insert(
             "outputSchema".to_string(),
             canonicalize_output_schema(output_schema),
@@ -239,4 +242,22 @@ fn looks_like_tuple_keys(map: &Map<String, Value>) -> bool {
         idx += 1;
     }
     idx > 0 && map.len() == idx
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn canonicalize_tool_schema_preserves_null_output_schema() {
+        let tool_schema = json!({
+            "name": "no-output",
+            "inputSchema": {"type": "object"},
+            "outputSchema": null
+        });
+
+        assert_eq!(canonicalize_tool_schema(&tool_schema), tool_schema);
+    }
 }


### PR DESCRIPTION
When Wassette starts with components already on disk, it registers their cached tool metadata before compiling them in the background. A client that sends `tools/list` during that window receives a tool named `<unnamed>` with no description or input schema, and cannot call it; once compilation finishes, the same process reports the tool correctly.

## The bug

The cached metadata is valid and contains a complete tool object:

```json
{
  "name": "fetch",
  "description": "Fetch data from a URL",
  "inputSchema": { "type": "object" },
  "outputSchema": { "type": "string" }
}
```

Two metadata-read paths pass that whole object to `canonicalize_output_schema`, which expects only the value of `outputSchema`. Because the tool object has no top-level `"type": "object"`, the canonicalizer wraps all of it under `properties.result`:

```json
{
  "type": "object",
  "properties": {
    "result": {
      "name": "fetch",
      "description": "Fetch data from a URL",
      "inputSchema": { "type": "object" },
      "outputSchema": { "type": "string" }
    }
  },
  "required": ["result"]
}
```

`parse_tool_schema` then looks for `name`, `description`, and `inputSchema` at the top level, finds none, and applies its `<unnamed>`, `No description available`, and `{}` fallbacks.

This is timing-dependent rather than persistent metadata corruption. `tools/list` immediately after initialization takes the broken cached path; after background compilation finishes, it takes the live component path and returns the correct tool.

## The change

Add `canonicalize_tool_schema`, which preserves the complete tool object and canonicalizes only its `outputSchema` field. Both cached metadata paths now use it, covering the direct component-schema fallback and the fast startup registry population.

The direct fallback now validates the cached metadata stamp before advertising a tool, matching the registry population path so stale metadata cannot look callable while a changed component recompiles. An explicit `outputSchema: null` remains null rather than being wrapped into an invalid result schema.

The CLI `inspect` command now reads the corrected top-level tool shape instead of depending on the accidental `properties.result` nesting. Existing metadata files require no migration because the data on disk was already correct.

## Verification

- A regression test writes the same canonical output schema shape persisted in production, reads it through `get_component_schema`, populates the startup registry from it, and asserts that the tool name, description, input schema, and output schema survive both paths unchanged.
- Changing the component after the metadata is written makes the fallback reject the stale schema, and an explicit null output schema is preserved.
- An immediate `tools/list` during startup restoration reports `fetch` with its `url` input instead of `<unnamed>` with an empty schema.
- `wassette inspect fetch_rs` reports the cached tool as `fetch`.
- `just test`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo machete` pass.
- `just test-mcp-inspector` passes.
- The external Copilot client smoke test loads a component and calls its exported tool successfully against the release build.