### PR TITLE
feat(release): support curated release highlights

### DIFF
--- a/.github/release-highlights/v0.7.0.md
+++ b/.github/release-highlights/v0.7.0.md
@@ -1,0 +1,37 @@
+## Highlights
+
+### MCP protocol and serving
+
+- Streamable HTTP now supports the stateless MCP lifecycle from protocol revision `2026-07-28`, alongside the existing session-based lifecycle, with optional JSON responses and a subscription stream for tool-list changes (#759).
+- Deployments can configure the Streamable HTTP Host allowlist through `--allowed-host`, `WASSETTE_ALLOWED_HOSTS`, or `config.toml`, while the secure loopback-only default remains unchanged (#757).
+- `serve --manifest` can opt into degraded startup with `--continue-on-provisioning-failure`, serving components that provisioned successfully while reporting those that did not (#785).
+
+### Component provisioning and tools
+
+- Manifest-declared policies are now attached to the component they were synthesized for, so declared network permissions work instead of failing closed with an empty allowlist (#777).
+- Manifest entries can explicitly declare no permissions, and the worked manifest examples are valid and documented (#780, #784).
+- `run` and `serve` now honor the global `--component-dir`, keeping startup restoration and later component operations on the same directory (#767).
+- Cached tools restored during startup retain their names, descriptions, input schemas, and callable identities while components compile in the background (#788).
+- Tool-name collisions are reported when components register, before the first ambiguous call fails (#786).
+- Component load failures preserve their full cause chain across the CLI, MCP responses, logs, and manifest provisioning (#782).
+
+### Examples
+
+- The `get-weather-js` and `get-open-meteo-weather-js` examples now import `wasi:config/store@0.2.0-rc.1`, matching the host runtime (#781).
+- `arxiv-rs` once again exports its three component functions after regenerating its WIT bindings (#787).
+- Release publishing no longer includes the unpublished `context7-rs` example, and main-branch example builds now move the `latest` tag as documented (#773, #783).
+
+### Release engineering
+
+- A new opt-in `latest` prerelease channel builds any commit into six immutable platform assets without changing what stable installers resolve (#769).
+- Release builds use a shared matrix workflow, channel retention prunes by publication time, and the release process is documented end to end (#768, #775, #776).
+- MCP client and Inspector harnesses now cover both protocol generations and the documented terminal clients (#759, #774).
+- Coverage runs once instead of twice, and Rust caches can fall back to partial restores (#758, #778, #779).
+
+### Installation
+
+- The installer no longer rejects supported Bash shells whose executable path is not literally `/bin/bash` (#766).
+
+### Breaking changes
+
+- `mcp_server::handle_resources_list` no longer accepts an unused `serde_json::Value` request argument. Library callers should remove that argument (#759).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,13 +95,27 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${RELEASE_TAG#v}"
+          GENERATED_NOTES=$(mktemp)
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             "/repos/$GITHUB_REPOSITORY/releases/generate-notes" \
             -f tag_name="$RELEASE_TAG" \
             -f target_commitish="$GITHUB_SHA" \
-            --jq '.body' > release-notes.md
+            --jq '.body' > "$GENERATED_NOTES"
+
+          HIGHLIGHTS_FILE=".github/release-highlights/${RELEASE_TAG}.md"
+          if [ -f "$HIGHLIGHTS_FILE" ]; then
+            {
+              cat "$HIGHLIGHTS_FILE"
+              printf '\n\n'
+              cat "$GENERATED_NOTES"
+            } > release-notes.md
+          else
+            mv "$GENERATED_NOTES" release-notes.md
+          fi
+          rm -f "$GENERATED_NOTES"
+
           cat >> release-notes.md <<EOF
 
           ## Downloads

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,6 +40,12 @@ pull request titles and the release notes take care of themselves. The only
 tuning in [`.github/release.yml`](.github/release.yml) is excluding bot-authored
 pull requests (like dependency bumps) so the list stays focused.
 
+For a release that needs a curated introduction, add
+`.github/release-highlights/vX.Y.Z.md` before dispatching the release workflow.
+The workflow prepends that file to the generated "What's Changed" section.
+Because published releases are immutable, the highlights file must be reviewed
+and merged before the workflow publishes the release.
+
 ## Release Versioning
 
 Wassette uses semantic versioning. All releases follow the format `vX.Y.Z`, where X is the major version, Y is the minor version, and Z is the patch version.


### PR DESCRIPTION
The release job creates the draft, uploads the assets and publishes the immutable release in one sequence. There is no point in that sequence at which a human can safely edit the draft, and an immutable release cannot be edited once published. So today the only notes a release can carry are the generated flat "What's Changed" list.

This adds an optional curated block. When `.github/release-highlights/v<version>.md` exists on `main` at dispatch time, `release.yml` prepends it to the generated notes. When the file is absent the notes are byte-for-byte what they were before, so releases that do not want a summary are unaffected.

Also adds the highlights for `v0.7.0` and documents the mechanism in `RELEASE.md`.

### Verification

- The `Prepare release notes` block was extracted and syntax-checked with `bash -n`.
- The assembly was dry-run against the real generated notes for `v0.7.0` (`generate-notes` with `previous_tag_name=v0.6.0`, target `4ba0103`); the output opens with `## Highlights` and the generated `## What's Changed` list follows intact.
- Every pull request cited in the `v0.7.0` highlights appears in that generated list. The only merged pull requests not cited are #772 and #789, both release chores.

### Note on the release commit

Merging this moves `main` past `4ba0103`, so `v0.7.0` will be tagged at the resulting merge commit rather than at `4ba0103`. `Cargo.toml` still reads `0.7.0`, so `validate-release` is unaffected. This pull request will also appear as an entry in the generated `What's Changed` list.