### PR TITLE
chore: update winget and homebrew for v0.7.0

### DIFF
--- a/Formula/wassette.rb
+++ b/Formula/wassette.rb
@@ -3,25 +3,25 @@ class Wassette < Formula
   homepage "https://github.com/microsoft/wassette"
   # Change this to install a different version of wassette.
   # The release tag in GitHub must exist with a 'v' prefix (e.g., v0.1.0).
-  version "0.6.0"
+  version "0.7.0"
 
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_darwin_amd64.tar.gz"
-      sha256 "cafa5a0946484e6924c724cf46c1e4e7020a4d55f8061cfc655b49e4be5a7d8d"
+      sha256 "6aaaf6509f1f4830919b78e35f7218d9674133d5848d89255c7583dfc3d865fb"
     else
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_darwin_arm64.tar.gz"
-      sha256 "e0467689e5b647764f7b8e686622cde141a0923c00eca02a594bc8171407e598"
+      sha256 "601ed080c11c695d594ab987adaacfa4cc94dd5697d464a88ab656e66194621f"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_linux_amd64.tar.gz"
-      sha256 "1fbf2f342b07835ca9dca048bb889e27429becc6fbedbd1d296778fe38361fc9"
+      sha256 "c030964b92a1fb9862fc59b8c318099eba501f83a798b822cb9a394fb0f85f20"
     else
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_linux_arm64.tar.gz"
-      sha256 "4e82f5ee3a2c1eaacf2c740da4d9daaa8bb88359743983411d392f609f9e7520"
+      sha256 "596dd0831e9a1ce10042a07a58d5381dac243859e435e2ae53ecc573d0b92761"
     end
   end
 

--- a/winget/Microsoft.Wassette.yaml
+++ b/winget/Microsoft.Wassette.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.6.0.schema.json
 
 PackageIdentifier: Microsoft.Wassette
-PackageVersion: 0.6.0
+PackageVersion: 0.7.0
 PackageLocale: en-US
 Publisher: Microsoft Corporation
 PublisherUrl: https://github.com/microsoft/wassette
@@ -29,20 +29,20 @@ Tags:
 - sandbox
 - runtime
 - component
-ReleaseDate: 2026-08-17
+ReleaseDate: 2026-08-29
 Installers:
 - Architecture: x64
   InstallerType: zip
-  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.6.0/wassette_0.6.0_windows_amd64.zip
-  InstallerSha256: e7fabe0bd2a14a6021b813f73857faa691033d54d75fac0912e4f1a1b379162b
+  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.7.0/wassette_0.7.0_windows_amd64.zip
+  InstallerSha256: ec451bcd75da068785016fead7547076f2a6832f3f9d889d9c61108ac161c1b7
   NestedInstallerType: portable
   NestedInstallerFiles:
   - RelativeFilePath: wassette.exe
     PortableCommandAlias: wassette
 - Architecture: arm64
   InstallerType: zip
-  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.6.0/wassette_0.6.0_windows_arm64.zip
-  InstallerSha256: 79899f95246ad063f4a57cb4108d1d3fd9a487ce69bbe9ba0e15ed5d230d9ab0
+  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.7.0/wassette_0.7.0_windows_arm64.zip
+  InstallerSha256: 3f1c6eea738a53ea2b3bc09cda9814b18c95043c7301a446025d5da6fefbd3ca
   NestedInstallerType: portable
   NestedInstallerFiles:
   - RelativeFilePath: wassette.exe


### PR DESCRIPTION
Updates `Formula/wassette.rb` (Homebrew) and `winget/Microsoft.Wassette.yaml` (WinGet) to `0.7.0`, with the SHA256 checksums of the published `v0.7.0` assets.

### Why this was opened by hand

The `update-package-manifests` workflow produced this branch correctly but could not open the pull request:

```
GitHub Actions is not permitted to create or approve pull requests.
```

Run: https://github.com/microsoft/wassette/actions/runs/33227205117

Every earlier step of that run succeeded — assets downloaded, checksums computed, both manifests rewritten, branch `release/v0.7.0-post` pushed at `b595e9b`. Only the final `Create Pull Request` step failed, so the branch content is exactly what the workflow generated; nothing here was hand-edited.

The durable fix is the repository Actions setting **Allow GitHub Actions to create and approve pull requests**, which `RELEASE.md` already lists as a prerequisite. It is currently disabled.

### Verification

All six published assets were downloaded and hashed locally; every checksum in both manifests matches:

| Asset | SHA256 |
| --- | --- |
| `darwin_amd64.tar.gz` | `6aaaf650…865fb` |
| `darwin_arm64.tar.gz` | `601ed080…4621f` |
| `linux_amd64.tar.gz` | `c030964b…f85f20` |
| `linux_arm64.tar.gz` | `596dd083…b92761` |
| `windows_amd64.zip` | `ec451bcd…61c1b7` |
| `windows_arm64.zip` | `3f1c6eea…fbd3ca` |