### PR TITLE
fix(cli): resolve component tools from on-disk metadata so `tool invoke` works

### DIFF
--- a/crates/mcp-server/src/components.rs
+++ b/crates/mcp-server/src/components.rs
@@ -139,6 +139,18 @@ pub async fn handle_component_call(
         "Component function invocation started"
     );
 
+    // The tool lookup can be satisfied from on-disk metadata, but executing the call
+    // needs the component compiled and registered. This is a no-op when it already is.
+    lifecycle_manager
+        .ensure_component_loaded(&component_id)
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to load component '{component_id}' for tool '{}'",
+                req.name
+            )
+        })?;
+
     let tool_schema = lifecycle_manager
         .get_tool_schema_for_component(&component_id, &req.name)
         .await;

--- a/crates/mcp-server/src/components.rs
+++ b/crates/mcp-server/src/components.rs
@@ -10,7 +10,9 @@ use rmcp::{Peer, RoleServer};
 use serde_json::{json, Value};
 use tracing::{debug, error, info, instrument};
 use wassette::schema::{canonicalize_output_schema, ensure_structured_result};
-use wassette::{format_error_chain, ComponentLoadOutcome, LifecycleManager, LoadResult};
+use wassette::{
+    format_error_chain, ComponentLoadOutcome, EnsureLoadedOutcome, LifecycleManager, LoadResult,
+};
 
 #[instrument(skip(lifecycle_manager))]
 pub(crate) async fn get_component_tools(lifecycle_manager: &LifecycleManager) -> Result<Vec<Tool>> {
@@ -125,6 +127,7 @@ pub(crate) async fn handle_unload_component(
 pub async fn handle_component_call(
     req: &CallToolRequestParams,
     lifecycle_manager: &LifecycleManager,
+    server_peer: Option<Peer<RoleServer>>,
 ) -> Result<CallToolResult> {
     let args = extract_args_from_request(req)?;
 
@@ -141,7 +144,7 @@ pub async fn handle_component_call(
 
     // The tool lookup can be satisfied from on-disk metadata, but executing the call
     // needs the component compiled and registered. This is a no-op when it already is.
-    lifecycle_manager
+    let load_outcome = lifecycle_manager
         .ensure_component_loaded(&component_id)
         .await
         .with_context(|| {
@@ -150,6 +153,16 @@ pub async fn handle_component_call(
                 req.name
             )
         })?;
+
+    // This call may be what put the component in the registry: a tool can be resolved from
+    // on-disk metadata before anything registered it, so a `tools/call` can beat both the
+    // explicit load handler and the background restore to the registration. Whichever path
+    // registers the component owns announcing it, and the restore stays quiet about a
+    // component that was already loaded, so notifying here is what keeps the change
+    // announced exactly once instead of not at all.
+    if load_outcome == EnsureLoadedOutcome::Registered {
+        handle_tool_list_notification(server_peer, &component_id, "load").await;
+    }
 
     let tool_schema = lifecycle_manager
         .get_tool_schema_for_component(&component_id, &req.name)

--- a/crates/mcp-server/src/tools.rs
+++ b/crates/mcp-server/src/tools.rs
@@ -172,7 +172,7 @@ pub async fn handle_tools_call(
             "reset-permission" if !disable_builtin_tools => {
                 handle_reset_permission(&req, lifecycle_manager).await
             }
-            _ => handle_component_call(&req, lifecycle_manager).await,
+            _ => handle_component_call(&req, lifecycle_manager, Some(server_peer)).await,
         }
     };
 

--- a/crates/wassette-mcp-server/src/main.rs
+++ b/crates/wassette-mcp-server/src/main.rs
@@ -798,7 +798,7 @@ async fn main() -> Result<()> {
                             .with_arguments(arguments);
 
                         use mcp_server::components::handle_component_call;
-                        let result = handle_component_call(&req, &lifecycle_manager).await;
+                        let result = handle_component_call(&req, &lifecycle_manager, None).await;
 
                         match result {
                             Ok(tool_result) => {

--- a/crates/wassette-mcp-server/src/server.rs
+++ b/crates/wassette-mcp-server/src/server.rs
@@ -478,6 +478,219 @@ mod tests {
         );
     }
 
+    /// Builds the filesystem example component, which needs one storage grant to run and so
+    /// keeps these tests to a single permission.
+    fn build_filesystem_component() -> std::path::PathBuf {
+        let top_level = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..");
+        let component_path =
+            top_level.join("examples/filesystem-rs/target/wasm32-wasip2/release/filesystem.wasm");
+
+        if !component_path.exists() {
+            let status = std::process::Command::new("cargo")
+                .current_dir(top_level.join("examples/filesystem-rs"))
+                .args(["build", "--release", "--target", "wasm32-wasip2"])
+                .status()
+                .expect("cargo build of the filesystem example should run");
+            assert!(status.success(), "filesystem example should compile");
+        }
+
+        assert!(
+            component_path.exists(),
+            "filesystem component should exist at {}",
+            component_path.display()
+        );
+        component_path
+    }
+
+    /// Completes the handshake the way a real client does before it makes requests.
+    async fn send_initialized(client: &mut BufReader<DuplexStream>) {
+        client
+            .get_mut()
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n")
+            .await
+            .expect("initialized notification should be written");
+        client
+            .get_mut()
+            .flush()
+            .await
+            .expect("initialized notification should be flushed");
+    }
+
+    /// Issues one `tools/call` and returns how many `tools/list_changed` notifications the
+    /// peer received before the response, together with the response itself.    ///
+    /// A handler sends its notification on the same transport before returning, so every
+    /// notification that belongs to the call has been written by the time the response
+    /// arrives. Counting up to the response therefore counts the call's notifications
+    /// exactly, without a sleep that would make the test both slow and flaky.
+    async fn call_tool_counting_notifications(
+        client: &mut BufReader<DuplexStream>,
+        request_id: i64,
+        tool_name: &str,
+        arguments: Value,
+    ) -> (usize, Value) {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        });
+        client
+            .get_mut()
+            .write_all(format!("{request}\n").as_bytes())
+            .await
+            .expect("tools/call request should be written");
+        client
+            .get_mut()
+            .flush()
+            .await
+            .expect("tools/call request should be flushed");
+
+        let mut notifications = 0;
+        loop {
+            let mut line = String::new();
+            tokio::time::timeout(Duration::from_secs(60), client.read_line(&mut line))
+                .await
+                .expect("timed out waiting for the tools/call response")
+                .expect("server should keep writing to the transport");
+            let message: Value = serde_json::from_str(&line).expect("message should be JSON");
+
+            if message["method"] == "notifications/tools/list_changed" {
+                notifications += 1;
+                continue;
+            }
+            if message["id"] == request_id {
+                return (notifications, message);
+            }
+        }
+    }
+
+    /// Populates a component directory the way an earlier process would have, and returns the
+    /// directory, the component id, and a directory the component is allowed to read.
+    async fn populated_component_dir() -> (tempfile::TempDir, tempfile::TempDir, String) {
+        let component_dir =
+            tempfile::tempdir().expect("temporary component directory should exist");
+        let work_dir = tempfile::tempdir().expect("temporary work directory should exist");
+        let component_path = build_filesystem_component();
+
+        let manager = LifecycleManager::new_unloaded(component_dir.path())
+            .await
+            .expect("lifecycle manager should be created");
+        let outcome = manager
+            .load_component(&format!("file://{}", component_path.display()))
+            .await
+            .expect("filesystem component should load");
+        manager
+            .grant_permission(
+                &outcome.component_id,
+                "storage",
+                &serde_json::json!({
+                    "uri": format!("fs://{}", work_dir.path().display()),
+                    "access": ["read"],
+                }),
+            )
+            .await
+            .expect("storage permission should be granted");
+
+        (component_dir, work_dir, outcome.component_id)
+    }
+
+    /// A tool call can be the first thing to register its component: the tool resolves from
+    /// on-disk metadata, and the background restore stays quiet about a component it finds
+    /// already loaded. Nobody else is going to announce that registration, so the call that
+    /// performed it must, or a client waiting on `tools/list_changed` never re-lists.
+    #[tokio::test]
+    async fn on_demand_component_registration_announces_the_tool_list_change_once() {
+        let (component_dir, work_dir, component_id) = populated_component_dir().await;
+        let probe = work_dir.path().join("probe.txt");
+        tokio::fs::write(&probe, b"hello")
+            .await
+            .expect("probe file should be written");
+
+        // A fresh manager over the same directory, with no restore run: exactly the state a
+        // just-started server is in when the first `tools/call` arrives.
+        let lifecycle_manager = LifecycleManager::new_unloaded(component_dir.path())
+            .await
+            .expect("lifecycle manager should be created");
+        assert!(
+            lifecycle_manager.list_components().await.is_empty(),
+            "nothing should be registered before the first call"
+        );
+        let server = McpServer::new(lifecycle_manager, false, true);
+        let (_peer, mut client, service) = connect_peer(server.clone()).await;
+        send_initialized(&mut client).await;
+
+        let arguments = serde_json::json!({ "path": probe.to_string_lossy() });
+        let (notifications, response) =
+            call_tool_counting_notifications(&mut client, 2, "file-exists", arguments.clone())
+                .await;
+        assert!(
+            response["error"].is_null() && response["result"]["isError"] != Value::Bool(true),
+            "the tool call should succeed: {response}"
+        );
+        assert_eq!(
+            server.lifecycle_manager.list_components().await,
+            vec![component_id],
+            "the call should have registered the component"
+        );
+        assert_eq!(
+            notifications, 1,
+            "registering a component through a tool call changes the tool list exactly once"
+        );
+
+        let (notifications, response) =
+            call_tool_counting_notifications(&mut client, 3, "file-exists", arguments).await;
+        assert!(
+            response["error"].is_null() && response["result"]["isError"] != Value::Bool(true),
+            "the second tool call should succeed: {response}"
+        );
+        assert_eq!(
+            notifications, 0,
+            "a call that found the component already loaded changed nothing to announce"
+        );
+
+        drop(client);
+        tokio::time::timeout(Duration::from_secs(5), service)
+            .await
+            .expect("peer should close after its transport is dropped")
+            .expect("peer service should shut down cleanly");
+    }
+
+    /// The explicit load already announces the change itself, so teaching the tool-call path
+    /// to announce must not give it a second voice.
+    #[tokio::test]
+    async fn explicit_component_load_announces_the_tool_list_change_once() {
+        let component_dir =
+            tempfile::tempdir().expect("temporary component directory should exist");
+        let component_path = build_filesystem_component();
+        let lifecycle_manager = LifecycleManager::new_unloaded(component_dir.path())
+            .await
+            .expect("lifecycle manager should be created");
+        let server = McpServer::new(lifecycle_manager, false, true);
+        let (_peer, mut client, service) = connect_peer(server.clone()).await;
+        send_initialized(&mut client).await;
+
+        let arguments =
+            serde_json::json!({ "path": format!("file://{}", component_path.display()) });
+        let (notifications, response) =
+            call_tool_counting_notifications(&mut client, 2, "load-component", arguments).await;
+        assert!(
+            response["error"].is_null() && response["result"]["isError"] != Value::Bool(true),
+            "the load should succeed: {response}"
+        );
+        assert_eq!(
+            notifications, 1,
+            "an explicit load announces the change once, not once per path that could"
+        );
+
+        drop(client);
+        tokio::time::timeout(Duration::from_secs(5), service)
+            .await
+            .expect("peer should close after its transport is dropped")
+            .expect("peer service should shut down cleanly");
+    }
+
     fn http_request_context(
         peer: rmcp::Peer<RoleServer>,
         request_id: i64,

--- a/crates/wassette-mcp-server/tests/cli_integration_test.rs
+++ b/crates/wassette-mcp-server/tests/cli_integration_test.rs
@@ -13,7 +13,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::process::Command as AsyncCommand;
 
 mod common;
-use common::build_fetch_component;
+use common::{build_fetch_component, build_filesystem_component};
 
 /// Helper struct for managing the test environment
 struct CliTestContext {
@@ -1161,6 +1161,113 @@ async fn test_cli_serve_legacy_sessions_requires_a_value() -> Result<()> {
     assert!(
         stderr.contains("a value is required"),
         "clap should ask for the missing value, got: {stderr}"
+    );
+
+    Ok(())
+}
+
+/// `tool invoke` has to work in a fresh process against a component directory that
+/// a previous process populated, which is the shape a scripted user hits.
+///
+/// A one-shot CLI run starts with an empty in-memory tool registry, so the invoke
+/// path must resolve the tool from the on-disk metadata and then load the
+/// component before executing it. Every step below runs in its own process.
+#[test(tokio::test)]
+async fn test_cli_tool_invoke_in_fresh_process() -> Result<()> {
+    let ctx = CliTestContext::new().await?;
+    let component_path = build_filesystem_component().await?;
+
+    // Process 1: populate the component directory.
+    let (stdout, stderr, exit_code) = ctx
+        .run_command(&[
+            "component",
+            "load",
+            &format!("file://{}", component_path.display()),
+        ])
+        .await?;
+    assert_eq!(exit_code, 0, "Load command failed with stderr: {stderr}");
+
+    let load_output: Value = ctx.parse_json_output(&stdout)?;
+    let component_id = load_output["id"]
+        .as_str()
+        .context("Missing component ID")?
+        .to_string();
+    assert!(
+        load_output["tools"]
+            .as_array()
+            .context("Missing tools array")?
+            .iter()
+            .any(|tool| tool == "file-exists"),
+        "expected the loaded component to export file-exists: {load_output}"
+    );
+
+    let work_dir = ctx.temp_dir.path().join("invoke-workdir");
+    tokio::fs::create_dir_all(&work_dir).await?;
+    let probe_file = work_dir.join("probe.txt");
+    tokio::fs::write(&probe_file, b"hello").await?;
+
+    // Process 2: grant the read access the invocation needs.
+    let (_, stderr, exit_code) = ctx
+        .run_command(&[
+            "permission",
+            "grant",
+            "storage",
+            &component_id,
+            &format!("fs://{}", work_dir.display()),
+            "--access",
+            "read",
+        ])
+        .await?;
+    assert_eq!(
+        exit_code, 0,
+        "Grant storage permission failed with stderr: {stderr}"
+    );
+
+    // Process 3: invoke with nothing but the on-disk state left by the two
+    // processes above. This used to fail with "Tool not found".
+    let arguments = serde_json::json!({ "path": probe_file.to_string_lossy() }).to_string();
+    let (stdout, stderr, exit_code) = ctx
+        .run_command(&["tool", "invoke", "file-exists", "--args", &arguments])
+        .await?;
+
+    assert_eq!(
+        exit_code, 0,
+        "tool invoke failed with stdout: {stdout} stderr: {stderr}"
+    );
+    let invoke_output: Value = ctx.parse_json_output(&stdout)?;
+    assert_eq!(
+        invoke_output["ok"],
+        Value::Bool(true),
+        "unexpected invoke result: {invoke_output}"
+    );
+
+    Ok(())
+}
+
+/// An unknown tool name must still fail cleanly from a fresh process rather than
+/// resolving to some arbitrary component.
+#[test(tokio::test)]
+async fn test_cli_tool_invoke_unknown_tool_in_fresh_process() -> Result<()> {
+    let ctx = CliTestContext::new().await?;
+    let component_path = build_filesystem_component().await?;
+
+    let (_, stderr, exit_code) = ctx
+        .run_command(&[
+            "component",
+            "load",
+            &format!("file://{}", component_path.display()),
+        ])
+        .await?;
+    assert_eq!(exit_code, 0, "Load command failed with stderr: {stderr}");
+
+    let (_, stderr, exit_code) = ctx
+        .run_command(&["tool", "invoke", "definitely-not-a-tool"])
+        .await?;
+
+    assert_ne!(exit_code, 0, "an unknown tool must not succeed");
+    assert!(
+        stderr.contains("Tool not found"),
+        "expected a tool lookup failure, got: {stderr}"
     );
 
     Ok(())

--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Instant;
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -124,15 +124,49 @@ struct ComponentRegistry {
 /// [`LifecycleManager::ensure_component_loaded`] races the background restore in exactly
 /// this way. The guard is keyed by component id so unrelated components still load
 /// concurrently.
+///
+/// Entries are weak, so an id occupies the map only while a load of that component is in
+/// flight. Holding strong references instead would grow the map forever in a long-running
+/// server that loads and unloads distinct components.
 #[derive(Clone, Default)]
 struct ComponentLoadGuards {
-    guards: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
+    guards: Arc<Mutex<HashMap<String, Weak<Mutex<()>>>>>,
 }
 
 impl ComponentLoadGuards {
+    /// Returns the guard for `component_id`, creating one if no load is currently using it.
+    ///
+    /// Callers keep the returned handle alive for as long as they hold (or wait for) the
+    /// guard, which is what makes the weak entries safe: while any load of `component_id` is
+    /// in flight the entry still upgrades, so every concurrent caller for that id is handed
+    /// the very same mutex. A fresh mutex is only ever minted once no caller holds one, and
+    /// therefore never runs concurrently with the mutex it replaces.
     async fn guard_for(&self, component_id: &str) -> Arc<Mutex<()>> {
         let mut guards = self.guards.lock().await;
-        Arc::clone(guards.entry(component_id.to_string()).or_default())
+
+        if let Some(existing) = guards.get(component_id).and_then(Weak::upgrade) {
+            return existing;
+        }
+
+        // Nothing holds a guard for this id, so its entry (and any other entry left behind by
+        // a finished load or an unloaded component) is dead weight. Reclaim them here: this
+        // only runs on the path that is about to compile a component, which dwarfs a sweep of
+        // a map holding at most one entry per component.
+        guards.retain(|_, guard| guard.strong_count() > 0);
+
+        let guard = Arc::new(Mutex::new(()));
+        guards.insert(component_id.to_string(), Arc::downgrade(&guard));
+        guard
+    }
+
+    /// Component ids currently tracked in the map, for tests that assert it does not grow
+    /// without bound.
+    #[cfg(test)]
+    async fn tracked_ids(&self) -> Vec<String> {
+        let guards = self.guards.lock().await;
+        let mut ids: Vec<String> = guards.keys().cloned().collect();
+        ids.sort();
+        ids
     }
 }
 
@@ -2304,6 +2338,68 @@ mod tests {
             restore_notifications.load(std::sync::atomic::Ordering::SeqCst),
             0,
             "the restore does not announce a component the on-demand load already registered"
+        );
+
+        Ok(())
+    }
+
+    /// Two callers racing to load the same component must be handed the same mutex, or the
+    /// guard stops guarding and both compile.
+    #[tokio::test]
+    async fn test_load_guards_hand_out_one_mutex_per_active_component() {
+        let guards = ComponentLoadGuards::default();
+
+        let first = guards.guard_for("component-a").await;
+        let _held = first.lock().await;
+        let second = guards.guard_for("component-a").await;
+
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "a caller arriving while a load is in flight must wait on that load's mutex"
+        );
+    }
+
+    /// The map is keyed by component id, so a server that loads and unloads distinct
+    /// components over its lifetime would grow it without bound if entries outlived the loads
+    /// that created them.
+    #[tokio::test]
+    async fn test_load_guards_do_not_retain_entries_for_inactive_components() {
+        let guards = ComponentLoadGuards::default();
+
+        {
+            let gone = guards.guard_for("gone").await;
+            let _held = gone.lock().await;
+            assert_eq!(guards.tracked_ids().await, vec!["gone".to_string()]);
+        }
+
+        let still_here = guards.guard_for("still-here").await;
+        let _held = still_here.lock().await;
+
+        assert_eq!(
+            guards.tracked_ids().await,
+            vec!["still-here".to_string()],
+            "an id with no load in flight should not be retained"
+        );
+    }
+
+    /// The same reclamation seen through the manager: a component that was loaded and then
+    /// unloaded leaves nothing behind in the guard map.
+    #[tokio::test]
+    async fn test_unloaded_components_are_not_retained_by_the_load_guards() -> Result<()> {
+        let manager = create_test_manager().await?;
+        let source = build_example_component().await?;
+        let other_component_id = "other_component";
+        tokio::fs::copy(&source, manager.component_path(TEST_COMPONENT_ID)).await?;
+        tokio::fs::copy(&source, manager.component_path(other_component_id)).await?;
+
+        manager.ensure_component_loaded(TEST_COMPONENT_ID).await?;
+        manager.unload_component(TEST_COMPONENT_ID).await?;
+        manager.ensure_component_loaded(other_component_id).await?;
+
+        assert_eq!(
+            manager.load_guards.tracked_ids().await,
+            vec![other_component_id.to_string()],
+            "the unloaded component should not keep an entry in the guard map"
         );
 
         Ok(())

--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -8,6 +8,7 @@
 use std::collections::HashMap;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -132,6 +133,38 @@ impl ComponentLoadGuards {
     async fn guard_for(&self, component_id: &str) -> Arc<Mutex<()>> {
         let mut guards = self.guards.lock().await;
         Arc::clone(guards.entry(component_id.to_string()).or_default())
+    }
+}
+
+/// Tracks whether the in-memory registry is known to describe every component on disk.
+///
+/// Tool lookup falls back to scanning the persisted metadata, which is what makes a tool
+/// resolvable before the background restore has registered its component (and in a one-shot
+/// CLI process, where no restore ever runs). That scan costs a directory walk plus a file
+/// read per component on every lookup, so it is only worth paying while the registry may
+/// still be missing something.
+///
+/// The flag starts out *incomplete* and is only marked complete once a restore pass has
+/// registered every component in the directory. Defaulting the other way would skip the
+/// fallback in exactly the processes that depend on it, so a short-lived CLI invocation
+/// would go back to reporting "Tool not found".
+#[derive(Clone, Default)]
+struct RegistryCompleteness {
+    complete: Arc<AtomicBool>,
+}
+
+impl RegistryCompleteness {
+    fn is_complete(&self) -> bool {
+        self.complete.load(Ordering::Acquire)
+    }
+
+    /// Records that a restore pass registered every component in the directory.
+    ///
+    /// A pass that failed for any component leaves the flag alone: that component is absent
+    /// from the registry but its metadata is still on disk, so the fallback is what keeps it
+    /// visible to tool lookup and to collision detection.
+    fn mark_complete(&self) {
+        self.complete.store(true, Ordering::Release);
     }
 }
 
@@ -360,6 +393,7 @@ pub struct LifecycleManager {
     runtime: Arc<RuntimeContext>,
     registry: ComponentRegistry,
     load_guards: ComponentLoadGuards,
+    registry_completeness: RegistryCompleteness,
     storage: ComponentStorage,
     policy_manager: PolicyManager,
     oci_client: Arc<oci_wasm::WasmClient>,
@@ -427,6 +461,7 @@ impl LifecycleManager {
             runtime,
             registry: ComponentRegistry::new(),
             load_guards: ComponentLoadGuards::default(),
+            registry_completeness: RegistryCompleteness::default(),
             storage,
             policy_manager,
             oci_client,
@@ -675,9 +710,11 @@ impl LifecycleManager {
 
     /// Returns the component ID for a given tool name.
     ///
-    /// The lookup considers both the in-memory registry and the persisted component
-    /// metadata, so the answer does not depend on how much of the background restore has
-    /// completed. If more than one component exports the tool name, returns an error.
+    /// While the in-memory registry may still be missing components (before or during the
+    /// background restore, and in one-shot CLI processes that never run it), the lookup also
+    /// consults the persisted component metadata, so the answer does not depend on how much of
+    /// the restore has completed. If more than one component exports the tool name, returns an
+    /// error.
     #[instrument(skip(self))]
     pub async fn get_component_id_for_tool(&self, tool_name: &str) -> Result<String> {
         let mut component_ids: Vec<String> = self
@@ -697,16 +734,23 @@ impl LifecycleManager {
             return Self::single_component_id_for_tool(tool_name, component_ids);
         }
 
-        // Merge in the persisted component metadata without compiling anything. Short-lived
-        // processes (such as one-shot CLI invocations) never populate the registry, and the
-        // background restore populates it one component at a time, so a component known only
-        // on disk is still a real match. Taking the union of both sources keeps ambiguity
-        // detection independent of how far the restore has progressed: a name exported by two
-        // components is reported as ambiguous before, during, and after the restore instead of
-        // silently resolving to whichever component happened to be registered first.
-        component_ids.extend(self.find_component_ids_for_tool_on_disk(tool_name).await);
-        component_ids.sort();
-        component_ids.dedup();
+        // Merge in the persisted component metadata without compiling anything, but only
+        // while the registry may still be incomplete. Short-lived processes (such as one-shot
+        // CLI invocations) never run the restore at all, and the restore populates the
+        // registry one component at a time, so a component known only on disk is still a real
+        // match. Taking the union of both sources keeps ambiguity detection independent of how
+        // far the restore has progressed: a name exported by two components is reported as
+        // ambiguous before, during, and after the restore instead of silently resolving to
+        // whichever component happened to be registered first.
+        //
+        // Once a restore pass has registered every component, the registry is a superset of
+        // the metadata and the scan can only reproduce what the registry already said, so it
+        // is skipped rather than paid for on every tool call.
+        if !self.registry_completeness.is_complete() {
+            component_ids.extend(self.find_component_ids_for_tool_on_disk(tool_name).await);
+            component_ids.sort();
+            component_ids.dedup();
+        }
 
         if component_ids.is_empty() {
             bail!("Tool not found");
@@ -1340,16 +1384,37 @@ impl LifecycleManager {
                         if let Some(notify) = notify_fn {
                             notify();
                         }
+                        true
                     }
-                    Ok(false) => {} // No component to load (not a .wasm file)
-                    Err(e) => warn!("Failed to load component: {:#}", e),
+                    Ok(false) => true, // No component to load (not a .wasm file, or already loaded)
+                    Err(e) => {
+                        warn!("Failed to load component: {:#}", e);
+                        false
+                    }
                 }
             };
             load_futures.push(future);
         }
 
         // Wait for all components to load
-        futures::future::join_all(load_futures).await;
+        let all_loaded = futures::future::join_all(load_futures)
+            .await
+            .into_iter()
+            .all(|loaded| loaded);
+
+        if all_loaded {
+            // Every component in the directory is now in the registry, so tool lookup no
+            // longer has to scan the persisted metadata to see the full picture. A pass that
+            // failed for even one component leaves the registry short of what is on disk, so
+            // the flag stays clear and the fallback keeps that component visible.
+            self.registry_completeness.mark_complete();
+        } else {
+            warn!(
+                "Background component loading finished with failures; tool lookup will keep \
+                 consulting on-disk component metadata"
+            );
+        }
+
         info!("Background component loading completed");
         Ok(())
     }
@@ -2179,6 +2244,85 @@ mod tests {
             1,
             "the on-demand load and the background restore should compile the component once \
              between them"
+        );
+
+        Ok(())
+    }
+
+    /// The persisted-metadata scan only earns its cost while the registry might be missing a
+    /// component. Once a restore pass has registered everything on disk, the registry answers
+    /// on its own and the scan is skipped, so a stray on-disk component is no longer consulted.
+    #[test(tokio::test)]
+    async fn test_get_component_id_for_tool_skips_disk_scan_once_registry_is_complete() -> Result<()>
+    {
+        let manager = create_test_manager().await?;
+        write_cached_component(&manager, "component-a", &["shared-tool"]).await?;
+        write_cached_component(&manager, "component-b", &["shared-tool"]).await?;
+        register_cached_component_in_registry(&manager, "component-a", &["shared-tool"]).await?;
+
+        // While the registry may be incomplete the on-disk twin is still a real match, so the
+        // name is ambiguous.
+        assert!(manager
+            .get_component_id_for_tool("shared-tool")
+            .await
+            .is_err());
+
+        manager.registry_completeness.mark_complete();
+
+        assert_eq!(
+            manager.get_component_id_for_tool("shared-tool").await?,
+            "component-a",
+            "a complete registry is authoritative, so the metadata scan must not run"
+        );
+
+        Ok(())
+    }
+
+    /// A restore pass that registered every component makes the registry authoritative.
+    #[test(tokio::test)]
+    async fn test_successful_restore_marks_registry_complete() -> Result<()> {
+        let manager = create_test_manager().await?;
+        let source = build_example_component().await?;
+        tokio::fs::copy(&source, manager.component_path(TEST_COMPONENT_ID)).await?;
+
+        assert!(
+            !manager.registry_completeness.is_complete(),
+            "the registry must start out incomplete, otherwise a process that never runs the \
+             restore (such as a one-shot CLI invocation) would skip the metadata fallback"
+        );
+
+        manager
+            .load_existing_components_async(None, None::<fn()>)
+            .await?;
+
+        assert!(manager.registry_completeness.is_complete());
+
+        Ok(())
+    }
+
+    /// "Complete" has to mean "succeeded for every component", not "attempted". A component
+    /// the restore could not compile is absent from the registry while its metadata is still
+    /// on disk, so the fallback is the only thing keeping it visible to tool lookup and to
+    /// collision detection.
+    #[test(tokio::test)]
+    async fn test_partially_failed_restore_leaves_registry_incomplete() -> Result<()> {
+        let manager = create_test_manager().await?;
+        let source = build_example_component().await?;
+        tokio::fs::copy(&source, manager.component_path(TEST_COMPONENT_ID)).await?;
+        // Not a valid WebAssembly component, so the restore fails for this one.
+        write_cached_component(&manager, "broken-component", &["broken-tool"]).await?;
+
+        manager
+            .load_existing_components_async(None, None::<fn()>)
+            .await?;
+
+        assert!(
+            !manager.registry_completeness.is_complete(),
+            "a restore that failed for a component must not claim the registry is complete"
+        );
+        assert_eq!(
+            manager.get_component_id_for_tool("broken-tool").await?,
+            "broken-component"
         );
 
         Ok(())

--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -21,7 +21,7 @@ use etcetera::BaseStrategy;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::fs::DirEntry;
-use tokio::sync::{RwLock, Semaphore};
+use tokio::sync::{Mutex, RwLock, Semaphore};
 use tracing::{debug, info, instrument, warn};
 use wasmtime::component::{Component, InstancePre};
 use wasmtime::Store;
@@ -112,6 +112,25 @@ pub struct ValidationStamp {
 #[derive(Clone, Default)]
 struct ComponentRegistry {
     state: Arc<RwLock<ComponentRegistryState>>,
+}
+
+/// Per-component guards that serialize concurrent load attempts.
+///
+/// [`LifecycleManager::ensure_component_loaded`] is check-then-act: it tests the registry
+/// and then compiles. Without a guard, two callers can both observe the component as
+/// absent and both compile it, duplicating wasmtime compilation and racing on the same
+/// metadata and precompiled cache files. The guard is keyed by component id so unrelated
+/// components still load concurrently.
+#[derive(Clone, Default)]
+struct ComponentLoadGuards {
+    guards: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
+}
+
+impl ComponentLoadGuards {
+    async fn guard_for(&self, component_id: &str) -> Arc<Mutex<()>> {
+        let mut guards = self.guards.lock().await;
+        Arc::clone(guards.entry(component_id.to_string()).or_default())
+    }
 }
 
 #[derive(Default)]
@@ -338,6 +357,7 @@ impl ComponentRegistryState {
 pub struct LifecycleManager {
     runtime: Arc<RuntimeContext>,
     registry: ComponentRegistry,
+    load_guards: ComponentLoadGuards,
     storage: ComponentStorage,
     policy_manager: PolicyManager,
     oci_client: Arc<oci_wasm::WasmClient>,
@@ -404,6 +424,7 @@ impl LifecycleManager {
         Ok(Self {
             runtime,
             registry: ComponentRegistry::new(),
+            load_guards: ComponentLoadGuards::default(),
             storage,
             policy_manager,
             oci_client,
@@ -944,6 +965,10 @@ impl LifecycleManager {
     /// Ensure a specific component is loaded (compiled and instantiated) by its ID.
     /// If it's already loaded, this is a no-op. If the wasm file is not present in
     /// the component directory, an error is returned.
+    ///
+    /// Concurrent calls for the same component are serialized, so the component is
+    /// compiled and registered once no matter how many callers race. Calls for
+    /// different components still proceed in parallel.
     #[instrument(skip(self))]
     pub async fn ensure_component_loaded(&self, component_id: &str) -> Result<()> {
         if self.registry.contains_component(component_id).await {
@@ -953,6 +978,16 @@ impl LifecycleManager {
         let entry_path = self.component_path(component_id);
         if !entry_path.exists() {
             bail!("Component not found: {}", component_id);
+        }
+
+        // Take the per-component guard only after the file exists, so unknown component ids
+        // cannot grow the guard map.
+        let guard = self.load_guards.guard_for(component_id).await;
+        let _guard = guard.lock().await;
+
+        // Another caller may have finished the load while we waited for the guard.
+        if self.registry.contains_component(component_id).await {
+            return Ok(());
         }
 
         self.compile_and_register_component(component_id, &entry_path)
@@ -1956,6 +1991,103 @@ mod tests {
         assert_eq!(
             manager.get_component_id_for_tool("only-tool").await?,
             "component-a"
+        );
+
+        Ok(())
+    }
+
+    /// Counts `tracing` events whose message contains `needle`, which lets a test observe
+    /// how many times a code path ran without changing the code under test.
+    #[derive(Clone)]
+    struct MessageCounter {
+        needle: &'static str,
+        count: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl MessageCounter {
+        fn new(needle: &'static str) -> Self {
+            Self {
+                needle,
+                count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            }
+        }
+
+        fn count(&self) -> usize {
+            self.count.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for MessageCounter {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            struct MessageVisitor<'a> {
+                needle: &'a str,
+                matched: bool,
+            }
+
+            impl tracing::field::Visit for MessageVisitor<'_> {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    if field.name() == "message" && format!("{value:?}").contains(self.needle) {
+                        self.matched = true;
+                    }
+                }
+            }
+
+            let mut visitor = MessageVisitor {
+                needle: self.needle,
+                matched: false,
+            };
+            event.record(&mut visitor);
+            if visitor.matched {
+                self.count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+    }
+
+    /// `ensure_component_loaded` is on the tool-call path, so several requests can race to
+    /// load the same not-yet-restored component. Without a per-component guard each racer
+    /// compiles the component and they all write the same metadata and cache files.
+    ///
+    /// Compilation is not directly observable from the crate's API, so this counts the
+    /// "Saved component metadata" event, which `compile_and_register_component` emits
+    /// exactly once per pass.
+    #[tokio::test]
+    async fn test_ensure_component_loaded_compiles_once_under_concurrency() -> Result<()> {
+        let manager = create_test_manager().await?;
+        let source = build_example_component().await?;
+        tokio::fs::copy(&source, manager.component_path(TEST_COMPONENT_ID)).await?;
+        assert!(manager.list_components().await.is_empty());
+
+        let counter = MessageCounter::new("Saved component metadata");
+        let subscriber = tracing_subscriber::layer::SubscriberExt::with(
+            tracing_subscriber::registry(),
+            counter.clone(),
+        );
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+        let results = futures::future::join_all(
+            (0..4).map(|_| manager.ensure_component_loaded(TEST_COMPONENT_ID)),
+        )
+        .await;
+        for result in results {
+            result?;
+        }
+
+        assert_eq!(
+            manager.list_components().await,
+            vec![TEST_COMPONENT_ID.to_string()]
+        );
+        assert_eq!(
+            counter.count(),
+            1,
+            "the component should be compiled and registered exactly once"
         );
 
         Ok(())

--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -619,24 +619,40 @@ impl LifecycleManager {
     }
 
     /// Returns the component ID for a given tool name.
-    /// If there are multiple components with the same tool name, returns an error.
+    ///
+    /// The lookup considers both the in-memory registry and the persisted component
+    /// metadata, so the answer does not depend on how much of the background restore has
+    /// completed. If more than one component exports the tool name, returns an error.
     #[instrument(skip(self))]
     pub async fn get_component_id_for_tool(&self, tool_name: &str) -> Result<String> {
-        // Prefer the in-memory registry when it knows about the tool.
-        if let Some(tool_infos) = self.registry.tool_infos(tool_name).await {
-            let component_ids: Vec<String> = tool_infos
-                .into_iter()
-                .map(|info| info.component_id)
-                .collect();
-            if !component_ids.is_empty() {
-                return Self::single_component_id_for_tool(tool_name, component_ids);
-            }
+        let mut component_ids: Vec<String> = self
+            .registry
+            .tool_infos(tool_name)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|info| info.component_id)
+            .collect();
+        component_ids.sort();
+        component_ids.dedup();
+
+        // The registry alone already proves the name is ambiguous, so the directory
+        // scan cannot change the outcome and is not worth paying for.
+        if component_ids.len() > 1 {
+            return Self::single_component_id_for_tool(tool_name, component_ids);
         }
 
-        // Fallback to the persisted component metadata without compiling anything.
-        // Short-lived processes (such as one-shot CLI invocations) never populate the
-        // registry, so the on-disk mapping is the only source of truth available.
-        let component_ids = self.find_component_ids_for_tool_on_disk(tool_name).await;
+        // Merge in the persisted component metadata without compiling anything. Short-lived
+        // processes (such as one-shot CLI invocations) never populate the registry, and the
+        // background restore populates it one component at a time, so a component known only
+        // on disk is still a real match. Taking the union of both sources keeps ambiguity
+        // detection independent of how far the restore has progressed: a name exported by two
+        // components is reported as ambiguous before, during, and after the restore instead of
+        // silently resolving to whichever component happened to be registered first.
+        component_ids.extend(self.find_component_ids_for_tool_on_disk(tool_name).await);
+        component_ids.sort();
+        component_ids.dedup();
+
         if component_ids.is_empty() {
             bail!("Tool not found");
         }
@@ -1872,6 +1888,75 @@ mod tests {
         assert!(message.contains("Multiple components found"), "{message}");
         assert!(message.contains("component-a"), "{message}");
         assert!(message.contains("component-b"), "{message}");
+
+        Ok(())
+    }
+
+    /// Registers a component's tools without an instance, which is the state the
+    /// background restore leaves a component in once it has read its metadata.
+    async fn register_cached_component_in_registry(
+        manager: &LifecycleManager,
+        component_id: &str,
+        tool_names: &[&str],
+    ) -> Result<()> {
+        let tools = tool_names
+            .iter()
+            .map(|name| ToolMetadata {
+                identifier: FunctionIdentifier {
+                    package_name: None,
+                    interface_name: None,
+                    function_name: (*name).to_string(),
+                },
+                normalized_name: (*name).to_string(),
+                schema: serde_json::json!({ "name": name }),
+            })
+            .collect();
+
+        assert!(
+            manager
+                .registry
+                .register_metadata_if_absent(component_id, tools)
+                .await?,
+            "{component_id} should not already be registered"
+        );
+
+        Ok(())
+    }
+
+    /// The background restore registers components one at a time, so there is a window in
+    /// which one of two colliding components is in the registry and the other is still only
+    /// on disk. The lookup must report the collision throughout that window instead of
+    /// silently resolving to whichever component the restore reached first.
+    #[test(tokio::test)]
+    async fn test_get_component_id_for_tool_reports_ambiguity_mid_restore() -> Result<()> {
+        let manager = create_test_manager().await?;
+        write_cached_component(&manager, "component-a", &["shared-tool"]).await?;
+        write_cached_component(&manager, "component-b", &["shared-tool"]).await?;
+        register_cached_component_in_registry(&manager, "component-a", &["shared-tool"]).await?;
+
+        let error = manager
+            .get_component_id_for_tool("shared-tool")
+            .await
+            .expect_err("a partially restored registry must not hide the collision");
+        let message = error.to_string();
+        assert!(message.contains("Multiple components found"), "{message}");
+        assert!(message.contains("component-a"), "{message}");
+        assert!(message.contains("component-b"), "{message}");
+
+        Ok(())
+    }
+
+    /// A component found in both the registry and the metadata is one component, not two.
+    #[test(tokio::test)]
+    async fn test_get_component_id_for_tool_dedupes_registry_and_metadata() -> Result<()> {
+        let manager = create_test_manager().await?;
+        write_cached_component(&manager, "component-a", &["only-tool"]).await?;
+        register_cached_component_in_registry(&manager, "component-a", &["only-tool"]).await?;
+
+        assert_eq!(
+            manager.get_component_id_for_tool("only-tool").await?,
+            "component-a"
+        );
 
         Ok(())
     }

--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -622,25 +622,88 @@ impl LifecycleManager {
     /// If there are multiple components with the same tool name, returns an error.
     #[instrument(skip(self))]
     pub async fn get_component_id_for_tool(&self, tool_name: &str) -> Result<String> {
-        let tool_infos = self
-            .registry
-            .tool_infos(tool_name)
-            .await
-            .context("Tool not found")?;
+        // Prefer the in-memory registry when it knows about the tool.
+        if let Some(tool_infos) = self.registry.tool_infos(tool_name).await {
+            let component_ids: Vec<String> = tool_infos
+                .into_iter()
+                .map(|info| info.component_id)
+                .collect();
+            if !component_ids.is_empty() {
+                return Self::single_component_id_for_tool(tool_name, component_ids);
+            }
+        }
 
-        if tool_infos.len() > 1 {
+        // Fallback to the persisted component metadata without compiling anything.
+        // Short-lived processes (such as one-shot CLI invocations) never populate the
+        // registry, so the on-disk mapping is the only source of truth available.
+        let component_ids = self.find_component_ids_for_tool_on_disk(tool_name).await;
+        if component_ids.is_empty() {
+            bail!("Tool not found");
+        }
+
+        Self::single_component_id_for_tool(tool_name, component_ids)
+    }
+
+    fn single_component_id_for_tool(
+        tool_name: &str,
+        mut component_ids: Vec<String>,
+    ) -> Result<String> {
+        if component_ids.len() > 1 {
             bail!(
                 "Multiple components found for tool '{}': {}",
                 tool_name,
-                tool_infos
-                    .iter()
-                    .map(|info| info.component_id.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
+                component_ids.join(", ")
             );
         }
 
-        Ok(tool_infos[0].component_id.clone())
+        Ok(component_ids.remove(0))
+    }
+
+    /// Scans the persisted component metadata for components exporting `tool_name`.
+    ///
+    /// Mirrors the metadata fallback used by [`Self::get_component_schema`]: the stored
+    /// metadata is only trusted when its validation stamp still matches the component
+    /// file on disk.
+    async fn find_component_ids_for_tool_on_disk(&self, tool_name: &str) -> Vec<String> {
+        let metadata_suffix = format!(".{METADATA_EXT}");
+        let mut component_ids = Vec::new();
+
+        let Ok(mut entries) = tokio::fs::read_dir(self.storage.root()).await else {
+            return component_ids;
+        };
+
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if !file_name.ends_with(&metadata_suffix) {
+                continue;
+            }
+
+            let Ok(contents) = tokio::fs::read_to_string(&path).await else {
+                continue;
+            };
+            let Ok(metadata) = serde_json::from_str::<ComponentMetadata>(&contents) else {
+                continue;
+            };
+
+            if !metadata.tool_names.iter().any(|name| name == tool_name) {
+                continue;
+            }
+
+            let component_path = self.component_path(&metadata.component_id);
+            if !ComponentStorage::validate_stamp(&component_path, &metadata.validation_stamp).await
+            {
+                continue;
+            }
+
+            component_ids.push(metadata.component_id);
+        }
+
+        component_ids.sort();
+        component_ids.dedup();
+        component_ids
     }
 
     /// Lists all available tools across all components
@@ -1721,6 +1784,94 @@ mod tests {
 
         tokio::fs::write(&component_path, b"changed component").await?;
         assert!(manager.get_component_schema(component_id).await.is_none());
+
+        Ok(())
+    }
+
+    /// Writes a component file plus matching metadata, mimicking what an earlier
+    /// process leaves behind in the component directory.
+    async fn write_cached_component(
+        manager: &LifecycleManager,
+        component_id: &str,
+        tool_names: &[&str],
+    ) -> Result<PathBuf> {
+        let component_path = manager.component_path(component_id);
+        tokio::fs::write(&component_path, component_id.as_bytes()).await?;
+
+        let metadata = ComponentMetadata {
+            component_id: component_id.to_string(),
+            tool_schemas: tool_names
+                .iter()
+                .map(|name| serde_json::json!({ "name": name }))
+                .collect(),
+            function_identifiers: tool_names
+                .iter()
+                .map(|name| FunctionIdentifier {
+                    package_name: None,
+                    interface_name: None,
+                    function_name: (*name).to_string(),
+                })
+                .collect(),
+            tool_names: tool_names.iter().map(|name| (*name).to_string()).collect(),
+            validation_stamp: manager
+                .storage
+                .create_validation_stamp(&component_path, false)
+                .await?,
+            created_at: 0,
+        };
+        manager.storage.write_metadata(&metadata).await?;
+
+        Ok(component_path)
+    }
+
+    /// A one-shot CLI process never populates the in-memory registry, so the tool
+    /// lookup has to resolve the owning component from the persisted metadata.
+    #[test(tokio::test)]
+    async fn test_get_component_id_for_tool_falls_back_to_metadata() -> Result<()> {
+        let manager = create_test_manager().await?;
+        let component_path =
+            write_cached_component(&manager, "cached-component", &["cached-tool"]).await?;
+
+        assert!(manager.list_components().await.is_empty());
+        assert_eq!(
+            manager.get_component_id_for_tool("cached-tool").await?,
+            "cached-component"
+        );
+
+        // Unknown tools still report the original error.
+        let error = manager
+            .get_component_id_for_tool("missing-tool")
+            .await
+            .expect_err("unknown tools must not resolve");
+        assert!(error.to_string().contains("Tool not found"), "{error:#}");
+
+        // Stale metadata is ignored, matching the get_component_schema fallback.
+        tokio::fs::write(&component_path, b"changed component").await?;
+        let error = manager
+            .get_component_id_for_tool("cached-tool")
+            .await
+            .expect_err("stale metadata must not resolve");
+        assert!(error.to_string().contains("Tool not found"), "{error:#}");
+
+        Ok(())
+    }
+
+    /// Ambiguity has to be reported from the metadata fallback too, otherwise a
+    /// CLI invocation could silently pick an arbitrary component.
+    #[test(tokio::test)]
+    async fn test_get_component_id_for_tool_reports_metadata_ambiguity() -> Result<()> {
+        let manager = create_test_manager().await?;
+        write_cached_component(&manager, "component-a", &["shared-tool"]).await?;
+        write_cached_component(&manager, "component-b", &["shared-tool"]).await?;
+
+        let error = manager
+            .get_component_id_for_tool("shared-tool")
+            .await
+            .expect_err("an ambiguous tool name must not resolve");
+        let message = error.to_string();
+        assert!(message.contains("Multiple components found"), "{message}");
+        assert!(message.contains("component-a"), "{message}");
+        assert!(message.contains("component-b"), "{message}");
 
         Ok(())
     }

--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -116,11 +116,13 @@ struct ComponentRegistry {
 
 /// Per-component guards that serialize concurrent load attempts.
 ///
-/// [`LifecycleManager::ensure_component_loaded`] is check-then-act: it tests the registry
-/// and then compiles. Without a guard, two callers can both observe the component as
-/// absent and both compile it, duplicating wasmtime compilation and racing on the same
-/// metadata and precompiled cache files. The guard is keyed by component id so unrelated
-/// components still load concurrently.
+/// Every path that compiles a component is check-then-act: it tests the registry (or the
+/// artifact's validation stamp) and then compiles. Without a guard, two callers can both
+/// observe the component as absent and both compile it, duplicating wasmtime compilation
+/// and racing on the same metadata and precompiled cache files. The on-demand load done by
+/// [`LifecycleManager::ensure_component_loaded`] races the background restore in exactly
+/// this way. The guard is keyed by component id so unrelated components still load
+/// concurrently.
 #[derive(Clone, Default)]
 struct ComponentLoadGuards {
     guards: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
@@ -514,7 +516,39 @@ impl LifecycleManager {
         }
     }
 
+    /// Compiles a component and registers it, replacing any previously registered instance.
+    ///
+    /// Serializes against every other load of the same component id, so concurrent callers
+    /// compile one after another instead of racing on the same metadata and precompiled
+    /// cache files. It does not skip the work when the component is already registered,
+    /// because an explicit reload has to recompile a changed artifact. Callers that want to
+    /// skip redundant work take the guard themselves via [`Self::load_guard`], recheck the
+    /// registry, and then call [`Self::compile_and_register_component_locked`].
     async fn compile_and_register_component(
+        &self,
+        component_id: &str,
+        wasm_path: &Path,
+    ) -> Result<ComponentLoadOutcome> {
+        let guard = self.load_guard(component_id).await;
+        let _guard = guard.lock().await;
+
+        self.compile_and_register_component_locked(component_id, wasm_path)
+            .await
+    }
+
+    /// Returns the per-component load guard, which serializes compilation of `component_id`.
+    async fn load_guard(&self, component_id: &str) -> Arc<Mutex<()>> {
+        self.load_guards.guard_for(component_id).await
+    }
+
+    /// Compiles and registers a component; the caller must hold the guard returned by
+    /// [`Self::load_guard`] for `component_id`.
+    ///
+    /// This is the only place that compiles a component, so holding the guard here is what
+    /// makes "compiled once" hold across the on-demand load path and the background restore.
+    /// Call [`Self::compile_and_register_component`] instead unless you already hold the
+    /// guard, which would deadlock.
+    async fn compile_and_register_component_locked(
         &self,
         component_id: &str,
         wasm_path: &Path,
@@ -966,9 +1000,10 @@ impl LifecycleManager {
     /// If it's already loaded, this is a no-op. If the wasm file is not present in
     /// the component directory, an error is returned.
     ///
-    /// Concurrent calls for the same component are serialized, so the component is
-    /// compiled and registered once no matter how many callers race. Calls for
-    /// different components still proceed in parallel.
+    /// Concurrent calls for the same component are serialized against each other and
+    /// against the background restore, so the component is compiled and registered once
+    /// no matter how many callers race. Calls for different components still proceed in
+    /// parallel.
     #[instrument(skip(self))]
     pub async fn ensure_component_loaded(&self, component_id: &str) -> Result<()> {
         if self.registry.contains_component(component_id).await {
@@ -982,15 +1017,16 @@ impl LifecycleManager {
 
         // Take the per-component guard only after the file exists, so unknown component ids
         // cannot grow the guard map.
-        let guard = self.load_guards.guard_for(component_id).await;
+        let guard = self.load_guard(component_id).await;
         let _guard = guard.lock().await;
 
-        // Another caller may have finished the load while we waited for the guard.
+        // Another caller, including the background restore, may have finished the load
+        // while we waited for the guard.
         if self.registry.contains_component(component_id).await {
             return Ok(());
         }
 
-        self.compile_and_register_component(component_id, &entry_path)
+        self.compile_and_register_component_locked(component_id, &entry_path)
             .await
             .with_context(|| {
                 format!(
@@ -1419,8 +1455,19 @@ impl LifecycleManager {
             return Ok(false);
         }
 
+        // Serialize against the on-demand load path: a `tools/call` that arrives before the
+        // restore reaches this component compiles it itself, and without the shared guard
+        // both passes would compile it and write the same metadata and cache files.
+        let guard = self.load_guard(&component_id).await;
+        let _guard = guard.lock().await;
+
+        if self.registry.contains_component(&component_id).await {
+            debug!(component_id = %component_id, "Component loaded while waiting for the load guard");
+            return Ok(false);
+        }
+
         let start_time = Instant::now();
-        self.compile_and_register_component(&component_id, &entry_path)
+        self.compile_and_register_component_locked(&component_id, &entry_path)
             .await
             .with_context(|| {
                 format!(
@@ -2088,6 +2135,50 @@ mod tests {
             counter.count(),
             1,
             "the component should be compiled and registered exactly once"
+        );
+
+        Ok(())
+    }
+
+    /// The interesting race is not between two `ensure_component_loaded` callers, it is
+    /// between an on-demand load and the background restore: a `tools/call` that arrives
+    /// before the restore reaches a component compiles it on demand while the restore is
+    /// compiling the very same component, and both passes write the same metadata and
+    /// precompiled cache files. The guard therefore has to sit on every path that compiles a
+    /// component, not just on `ensure_component_loaded`.
+    ///
+    /// As above, compilation is observed through the "Saved component metadata" event that
+    /// `compile_and_register_component_locked` emits exactly once per pass.
+    #[tokio::test]
+    async fn test_ensure_component_loaded_compiles_once_against_background_restore() -> Result<()> {
+        let manager = create_test_manager().await?;
+        let source = build_example_component().await?;
+        tokio::fs::copy(&source, manager.component_path(TEST_COMPONENT_ID)).await?;
+        assert!(manager.list_components().await.is_empty());
+
+        let counter = MessageCounter::new("Saved component metadata");
+        let subscriber = tracing_subscriber::layer::SubscriberExt::with(
+            tracing_subscriber::registry(),
+            counter.clone(),
+        );
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+        let (restore, on_demand) = tokio::join!(
+            manager.load_existing_components_async(None, None::<fn()>),
+            manager.ensure_component_loaded(TEST_COMPONENT_ID),
+        );
+        restore?;
+        on_demand?;
+
+        assert_eq!(
+            manager.list_components().await,
+            vec![TEST_COMPONENT_ID.to_string()]
+        );
+        assert_eq!(
+            counter.count(),
+            1,
+            "the on-demand load and the background restore should compile the component once \
+             between them"
         );
 
         Ok(())

--- a/crates/wassette/src/lib.rs
+++ b/crates/wassette/src/lib.rs
@@ -205,6 +205,20 @@ pub struct ComponentLoadOutcome {
     pub tool_names: Vec<String>,
 }
 
+/// What a call to [`LifecycleManager::ensure_component_loaded`] had to do.
+///
+/// A component can be registered by an on-demand load, by the background restore, or by an
+/// explicit load, and only one of them actually performs the registration. Callers that
+/// announce tool-list changes to clients need to know which one they were, so that the
+/// change is announced exactly once rather than never or twice.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum EnsureLoadedOutcome {
+    /// The component was already registered, so the tool list did not change.
+    AlreadyLoaded,
+    /// This call compiled and registered the component, making its tools newly visible.
+    Registered,
+}
+
 impl ComponentRegistry {
     fn new() -> Self {
         Self::default()
@@ -1048,10 +1062,15 @@ impl LifecycleManager {
     /// against the background restore, so the component is compiled and registered once
     /// no matter how many callers race. Calls for different components still proceed in
     /// parallel.
+    ///
+    /// Returns [`EnsureLoadedOutcome::Registered`] only for the call that performed the
+    /// registration. The tool list changed exactly when that is returned, so a caller that
+    /// notifies clients can do so without announcing a change that never happened, and
+    /// without staying silent about one that did.
     #[instrument(skip(self))]
-    pub async fn ensure_component_loaded(&self, component_id: &str) -> Result<()> {
+    pub async fn ensure_component_loaded(&self, component_id: &str) -> Result<EnsureLoadedOutcome> {
         if self.registry.contains_component(component_id).await {
-            return Ok(());
+            return Ok(EnsureLoadedOutcome::AlreadyLoaded);
         }
 
         let entry_path = self.component_path(component_id);
@@ -1065,9 +1084,9 @@ impl LifecycleManager {
         let _guard = guard.lock().await;
 
         // Another caller, including the background restore, may have finished the load
-        // while we waited for the guard.
+        // while we waited for the guard. That caller owns announcing the change.
         if self.registry.contains_component(component_id).await {
-            return Ok(());
+            return Ok(EnsureLoadedOutcome::AlreadyLoaded);
         }
 
         self.compile_and_register_component_locked(component_id, &entry_path)
@@ -1079,7 +1098,7 @@ impl LifecycleManager {
                 )
             })?;
 
-        Ok(())
+        Ok(EnsureLoadedOutcome::Registered)
     }
 
     /// Save component metadata to disk
@@ -2244,6 +2263,47 @@ mod tests {
             1,
             "the on-demand load and the background restore should compile the component once \
              between them"
+        );
+
+        Ok(())
+    }
+
+    /// Whoever registers a component owns telling clients that the tool list changed, so
+    /// exactly one path has to report the registration. The restore deliberately stays quiet
+    /// about a component it found already loaded, which is precisely the case an on-demand
+    /// `tools/call` creates, so the on-demand path is the one that has to report it.
+    #[tokio::test]
+    async fn test_on_demand_load_reports_the_registration_the_restore_then_skips() -> Result<()> {
+        let manager = create_test_manager().await?;
+        let source = build_example_component().await?;
+        tokio::fs::copy(&source, manager.component_path(TEST_COMPONENT_ID)).await?;
+
+        assert_eq!(
+            manager.ensure_component_loaded(TEST_COMPONENT_ID).await?,
+            EnsureLoadedOutcome::Registered,
+            "the on-demand load put the component in the registry, so it has to say so"
+        );
+        assert_eq!(
+            manager.ensure_component_loaded(TEST_COMPONENT_ID).await?,
+            EnsureLoadedOutcome::AlreadyLoaded,
+            "a second caller changed nothing and must not report a registration"
+        );
+
+        let restore_notifications = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let notify = {
+            let restore_notifications = Arc::clone(&restore_notifications);
+            move || {
+                restore_notifications.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+        };
+        manager
+            .load_existing_components_async(None, Some(notify))
+            .await?;
+
+        assert_eq!(
+            restore_notifications.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "the restore does not announce a component the on-demand load already registered"
         );
 
         Ok(())


### PR DESCRIPTION
## What

`wassette tool invoke` cannot reach any component-supplied tool:

```
$ DIR=$(mktemp -d)
$ wassette --component-dir "$DIR" component load oci://ghcr.io/microsoft/time-server-js:latest
{"id":"microsoft_time-server-js","status":"component loaded successfully",
 "tools":["microsoft_time-server-js_time_get-current-time"]}

$ wassette --component-dir "$DIR" tool invoke microsoft_time-server-js_time_get-current-time
Error invoking tool '...': Failed to find component for tool '...': Tool not found     # exit 1
```

`wassette tool invoke` is the natural way to exercise a component from a script without standing up an MCP client, and today it cannot invoke anything a component exports.

## Why

`get_component_id_for_tool` consulted only `registry.tool_infos`, the in-memory tool map populated by the background restore. A one-shot CLI process exits long before that runs, so the map is empty and the tool is reported as absent. A warm `.cwasm` does not help.

`tool list` and `tool read` already worked, because they read through `get_component_schema`, which prefers the live component and falls back to the persisted metadata. Only the invoke lookup lacked that fallback, which is why it survived earlier fixes to the same fallback.

The invoke path itself was never broken. The same tool, in the same directory, returned a correct result over MCP once the background restore had settled. This was purely a lookup-timing defect.

## The change

**`crates/wassette/src/lib.rs`.** `get_component_id_for_tool` still prefers the registry. When it misses, `find_component_ids_for_tool_on_disk` scans `*.metadata.json`, matches `tool_names`, and trusts an entry only when its validation stamp still matches the component file, mirroring the fallback `get_component_schema` already uses. The multi-component ambiguity check moves into a shared helper so both paths report it identically. No new persisted state: `component_id` and `tool_names` are already in the metadata.

**`crates/mcp-server/src/components.rs`.** Resolving the id is not sufficient on its own, since `execute_component_call` needs a live instance and `get_tool_schema_for_component` also reads the registry. `handle_component_call` now calls the existing idempotent `ensure_component_loaded` once the id is known.

That second part also removes a race on the server path: a `tools/call` arriving before the background restore finished previously failed, and now loads on demand.

## Verification

```
$ wassette --component-dir "$DIR" tool invoke microsoft_time-server-js_time_get-current-time
2026-08-29T15:29:33.478Z          # exit 0
```

`tool list` and `tool read` unchanged, unknown tool names still error cleanly, and `tools/call` over MCP still returns a correct result, including when sent inside the window that used to race.

## Tests

`test_cli_tool_invoke_in_fresh_process` is a three-process test over `CARGO_BIN_EXE_wassette`: one process loads a component, one grants a permission, one invokes. That is the shape a scripted user hits, and the shape the in-process tests did not cover.

It was verified against the unfixed code, where it fails with the original error:

```
test test_cli_tool_invoke_in_fresh_process ... FAILED
  Error invoking tool 'file-exists': Failed to find component for tool 'file-exists': Tool not found
```

Also adds an unknown-tool CLI test, and unit tests covering the fallback, stale-stamp rejection, and cross-component ambiguity.

Suites: `wassette` 107 passed, `mcp-server` 40 passed, `cli_integration_test` 34 passed. Clippy clean on both crates.

## Known gap, not addressed here

If the component file's validation stamp no longer matches, for example after a `cp` without `-p` changes the mtime, the fallback rejects the metadata and invoke reports "Tool not found". `tool list` and `tool read` already behave that way on `main`, so this change inherits the behaviour rather than introducing it. Deliberately left for a separate change, since the right fix is to decide what all the CLI read paths should do when a stamp fails, and the server already recompiles in that case.