### PR TITLE
test(mcp): use request metadata for the stateless peer fixture

### DIFF
--- a/crates/wassette-mcp-server/src/server.rs
+++ b/crates/wassette-mcp-server/src/server.rs
@@ -387,7 +387,7 @@ mod tests {
     use std::time::Duration;
 
     use axum::http::Request;
-    use rmcp::model::RequestId;
+    use rmcp::model::{ClientCapabilities, Implementation, RequestId, RequestMetaObject};
     use rmcp::ServiceExt;
     use serde_json::Value;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, DuplexStream};
@@ -395,7 +395,6 @@ mod tests {
     use super::*;
 
     const LEGACY_PROTOCOL_VERSION: &str = "2025-06-18";
-    const STATELESS_PROTOCOL_VERSION: &str = "2026-07-28";
 
     fn initialize_request(protocol_version: &str) -> String {
         format!(
@@ -405,17 +404,6 @@ mod tests {
 
     async fn connect_peer(
         server: McpServer,
-    ) -> (
-        rmcp::Peer<RoleServer>,
-        BufReader<DuplexStream>,
-        tokio::task::JoinHandle<()>,
-    ) {
-        connect_peer_with_version(server, LEGACY_PROTOCOL_VERSION).await
-    }
-
-    async fn connect_peer_with_version(
-        server: McpServer,
-        protocol_version: &str,
     ) -> (
         rmcp::Peer<RoleServer>,
         BufReader<DuplexStream>,
@@ -437,7 +425,7 @@ mod tests {
         let mut client = BufReader::new(client_transport);
         client
             .get_mut()
-            .write_all(initialize_request(protocol_version).as_bytes())
+            .write_all(initialize_request(LEGACY_PROTOCOL_VERSION).as_bytes())
             .await
             .expect("initialize request should be written");
         client
@@ -456,6 +444,10 @@ mod tests {
         assert!(
             response.get("error").is_none(),
             "initialize failed: {response}"
+        );
+        assert_eq!(
+            response["result"]["protocolVersion"], LEGACY_PROTOCOL_VERSION,
+            "test peer should negotiate the requested legacy version"
         );
 
         let peer = peer_receiver
@@ -510,9 +502,19 @@ mod tests {
             .expect("lifecycle manager should be created");
         let server = McpServer::new(lifecycle_manager, false, true);
 
-        let (peer, client, service) =
-            connect_peer_with_version(server.clone(), STATELESS_PROTOCOL_VERSION).await;
-        let context = http_request_context(peer, 1, Some("left-over-session"));
+        let (peer, client, service) = connect_peer(server.clone()).await;
+        let mut context = http_request_context(peer, 1, Some("left-over-session"));
+        // Stateless requests declare their version in _meta, not initialize.
+        // It must take precedence over the peer's legacy handshake state.
+        context.meta = RequestMetaObject::with_client_context(
+            ProtocolVersion::V_2026_07_28,
+            Implementation::new("peer-lifecycle-test", "1.0.0"),
+            ClientCapabilities::default(),
+        );
+        assert_eq!(
+            context.protocol_version(),
+            Some(ProtocolVersion::V_2026_07_28)
+        );
         server
             .list_tools(None, context)
             .await


### PR DESCRIPTION
This pull request refactors and improves the test code in `crates/wassette-mcp-server/src/server.rs`, focusing on simplifying peer connection setup and clarifying protocol version negotiation logic in tests. The main changes streamline the test helpers, ensure correct protocol version handling, and improve test clarity for both legacy and stateless protocol versions.

**Test helper simplification and protocol version negotiation:**

* Removed the `connect_peer_with_version` helper and consolidated peer connection logic into a single `connect_peer` function, always using the legacy protocol version for initialization. This reduces redundancy and simplifies test setup. [[1]](diffhunk://#diff-a6fc3e46e361db895be0da0053ef1fc9b3bf3a363bf1708f14e74ae9bf8a4e2bL412-L422) [[2]](diffhunk://#diff-a6fc3e46e361db895be0da0053ef1fc9b3bf3a363bf1708f14e74ae9bf8a4e2bL440-R428)
* Updated tests to explicitly check that the negotiated protocol version matches the requested legacy version, improving test coverage and clarity for protocol negotiation.

**Stateless protocol version handling:**

* In stateless protocol tests, now manually set the protocol version in the request context's `_meta` field using `RequestMetaObject::with_client_context`, ensuring the stateless protocol version takes precedence over the legacy handshake. This makes the test logic more explicit and robust.

**Test imports and constants:**

* Updated imports to include only the necessary types for the revised test setup, and removed the now-unused `STATELESS_PROTOCOL_VERSION` constant.