### PR TITLE
chore: update winget and homebrew for v0.7.1

### DIFF
--- a/Formula/wassette.rb
+++ b/Formula/wassette.rb
@@ -3,25 +3,25 @@ class Wassette < Formula
   homepage "https://github.com/microsoft/wassette"
   # Change this to install a different version of wassette.
   # The release tag in GitHub must exist with a 'v' prefix (e.g., v0.1.0).
-  version "0.7.0"
+  version "0.7.1"
 
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_darwin_amd64.tar.gz"
-      sha256 "6aaaf6509f1f4830919b78e35f7218d9674133d5848d89255c7583dfc3d865fb"
+      sha256 "ab9683638f439c53683d6473a1db681d02f21c47f30bfd41b61057795b2bbc88"
     else
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_darwin_arm64.tar.gz"
-      sha256 "601ed080c11c695d594ab987adaacfa4cc94dd5697d464a88ab656e66194621f"
+      sha256 "43b2bee25eb214a0672de4c9777b6e6e21049afd59e7acd372e9f3535ed0ab72"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_linux_amd64.tar.gz"
-      sha256 "c030964b92a1fb9862fc59b8c318099eba501f83a798b822cb9a394fb0f85f20"
+      sha256 "d902e8aa1b9cdae9fbb6dacc2f3a7e4d90772ef062421c34540e82a3a3f37363"
     else
       url "https://github.com/microsoft/wassette/releases/download/v#{version}/wassette_#{version}_linux_arm64.tar.gz"
-      sha256 "596dd0831e9a1ce10042a07a58d5381dac243859e435e2ae53ecc573d0b92761"
+      sha256 "3ecff9943749337b42df4d0dceeec5c7ffc5bee10c15438e692c164708408b7d"
     end
   end
 

--- a/winget/Microsoft.Wassette.yaml
+++ b/winget/Microsoft.Wassette.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.6.0.schema.json
 
 PackageIdentifier: Microsoft.Wassette
-PackageVersion: 0.7.0
+PackageVersion: 0.7.1
 PackageLocale: en-US
 Publisher: Microsoft Corporation
 PublisherUrl: https://github.com/microsoft/wassette
@@ -29,20 +29,20 @@ Tags:
 - sandbox
 - runtime
 - component
-ReleaseDate: 2026-08-29
+ReleaseDate: 2026-09-12
 Installers:
 - Architecture: x64
   InstallerType: zip
-  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.7.0/wassette_0.7.0_windows_amd64.zip
-  InstallerSha256: ec451bcd75da068785016fead7547076f2a6832f3f9d889d9c61108ac161c1b7
+  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.7.1/wassette_0.7.1_windows_amd64.zip
+  InstallerSha256: 098d3b1e9a433df203a723d78562518d43288178a39962ca63f96a1cabd0610b
   NestedInstallerType: portable
   NestedInstallerFiles:
   - RelativeFilePath: wassette.exe
     PortableCommandAlias: wassette
 - Architecture: arm64
   InstallerType: zip
-  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.7.0/wassette_0.7.0_windows_arm64.zip
-  InstallerSha256: 3f1c6eea738a53ea2b3bc09cda9814b18c95043c7301a446025d5da6fefbd3ca
+  InstallerUrl: https://github.com/microsoft/wassette/releases/download/v0.7.1/wassette_0.7.1_windows_arm64.zip
+  InstallerSha256: 5ea922a6855204c0a907c9b0a3d577f974699855c9c6beb564fd89fbe5b5fd82
   NestedInstallerType: portable
   NestedInstallerFiles:
   - RelativeFilePath: wassette.exe


### PR DESCRIPTION
This updates `Formula/wassette.rb` and `winget/Microsoft.Wassette.yaml` to v0.7.1 with the checksums of the published release assets. The `update-package-manifests` workflow generated this branch correctly but could not open the pull request, because GitHub Actions is not permitted to create pull requests on this repository, so it is opened by hand.

All six SHA256 values were recomputed from the published assets and match the manifests: the four in the formula (darwin amd64/arm64, linux amd64/arm64) and the two `InstallerSha256` values in the winget manifest.

Unrelated pre-existing observation, not introduced here: the formula test asserts `wassette-mcp-server #{version}` against `wassette --version`, but the binary prints `0.7.1 version.BuildInfo{...}` with no `wassette-mcp-server` prefix, so `brew test wassette` would fail. The same assertion is already on `main`; it does not affect `brew install`.
